### PR TITLE
fix: correct date format in news articles

### DIFF
--- a/content/news/acceptance-to-eccv2024/index.md
+++ b/content/news/acceptance-to-eccv2024/index.md
@@ -7,7 +7,7 @@ summary: ""
 authors: ["Shoma Iwai", "Atsuki Osanai", "Shunsuke Kitada", "Shinichiro Omachi"]
 tags: ["News"]
 categories: ["News"]
-date: 2024-07-01T:38:30+09:00
+date: 2024-07-01T00:00:00+09:00
 lastmod: 2024-07-01T08:00:00+00:00
 featured: false
 draft: false

--- a/content/news/appointed-uectokyo-kprogram-llm-research/index.md
+++ b/content/news/appointed-uectokyo-kprogram-llm-research/index.md
@@ -7,7 +7,7 @@ summary: ""
 authors: ["Shunsuke Kitada"]
 tags: ["News"]
 categories: ["News"]
-date: 2025-05-19T00:00:00-+09:00
+date: 2025-05-19T00:00:00+09:00
 lastmod: 2025-05-19T00:00:00+09:00
 featured: false
 draft: false


### PR DESCRIPTION
The date format in two news articles has been corrected to ensure consistency.

## Background
The original date formats contained an incorrect timezone offset which could lead to confusion.

## Changes
- Updated the date format in `acceptance-to-eccv2024/index.md` from `2024-07-01T:38:30+09:00` to `2024-07-01T00:00:00+09:00`.
- Updated the date format in `appointed-uectokyo-kprogram-llm-research/index.md` from `2025-05-19T00:00:00-+09:00` to `2025-05-19T00:00:00+09:00`.