### PR TITLE
feat: update image preview settings for publications

### DIFF
--- a/content/publication/chan2025yans/index.md
+++ b/content/publication/chan2025yans/index.md
@@ -51,7 +51,7 @@ url_video:
 image:
   caption: ""
   focal_point: ""
-  preview_only: false
+  preview_only: true
 
 # Associated Projects (optional).
 #   Associate this publication with one or more of your projects.

--- a/content/publication/nakamachi2025yans/index.md
+++ b/content/publication/nakamachi2025yans/index.md
@@ -51,7 +51,7 @@ url_video:
 image:
   caption: ""
   focal_point: ""
-  preview_only: false
+  preview_only: true
 
 # Associated Projects (optional).
 #   Associate this publication with one or more of your projects.

--- a/content/publication/takeshita2025yans/index.md
+++ b/content/publication/takeshita2025yans/index.md
@@ -51,7 +51,7 @@ url_video:
 image:
   caption: ""
   focal_point: ""
-  preview_only: false
+  preview_only: true
 
 # Associated Projects (optional).
 #   Associate this publication with one or more of your projects.


### PR DESCRIPTION
## Background
This commit modifies the image settings for multiple publication entries to enable preview-only mode.

## Changes
- Set `preview_only` to `true` in the image configuration for:
  - chan2025yans
  - nakamachi2025yans
  - takeshita2025yans