### PR TITLE
feat: update Hugo version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.119.0"
+          hugo-version: "0.136.5" # Make sure the version matches the one in https://github.com/shunk031/shunk031.github.io/blob/main/Makefile#L1
           extended: true
 
       - name: Build


### PR DESCRIPTION
## Background
The Hugo version used in the GitHub Actions workflow was outdated, which could lead to compatibility issues and missing features.

## Changes
- Updated the Hugo version from "0.119.0" to "0.136.5" to ensure alignment with the version specified in the Makefile.