### PR TITLE
fix(ci): harden lychee prune automation

### DIFF
--- a/.github/workflows/lychee-auto-merge.yml
+++ b/.github/workflows/lychee-auto-merge.yml
@@ -1,21 +1,58 @@
 name: Lychee Prune Auto-Merge
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_run:
+    workflows:
+      - Page Build
+    types:
+      - completed
 
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-  enable-auto-merge:
-    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'chore/prune-lychee-excludes' && github.event.pull_request.user.login == 'shunk031-me-bot[bot]'
+  merge-lychee-prune-pr:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'chore/prune-lychee-excludes'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Enable auto-merge for lychee prune PR
+      # Wait for the full Page Build workflow to finish before merging.
+      # `gh pr merge --auto` can merge too early when downstream checks have not started yet.
+      - name: Merge lychee prune PR after successful checks
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --squash "$PR_URL"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "No pull request is attached to this workflow run"
+            exit 0
+          fi
+
+          author="$(gh pr view "${PR_NUMBER}" --json author --jq '.author.login')"
+          base="$(gh pr view "${PR_NUMBER}" --json baseRefName --jq '.baseRefName')"
+          head="$(gh pr view "${PR_NUMBER}" --json headRefName --jq '.headRefName')"
+          state="$(gh pr view "${PR_NUMBER}" --json state --jq '.state')"
+          draft="$(gh pr view "${PR_NUMBER}" --json isDraft --jq '.isDraft')"
+
+          case "${author}" in
+            app/shunk031-me-bot|shunk031-me-bot[bot])
+              ;;
+            *)
+              echo "Skip non-bot PR: ${author}"
+              exit 0
+              ;;
+          esac
+
+          if [ "${base}" != "main" ] || [ "${head}" != "chore/prune-lychee-excludes" ]; then
+            echo "Skip unrelated PR: base=${base} head=${head}"
+            exit 0
+          fi
+
+          if [ "${state}" != "OPEN" ] || [ "${draft}" != "false" ]; then
+            echo "Skip non-open PR: state=${state} draft=${draft}"
+            exit 0
+          fi
+
+          gh pr merge "${PR_NUMBER}" --squash --delete-branch --match-head-commit "${HEAD_SHA}"

--- a/.lychee/exclude-permanent.txt
+++ b/.lychee/exclude-permanent.txt
@@ -4,3 +4,6 @@
 # Exclude the target site itself because an error will occur
 # if there is content that has not yet been deployed.
 shunk031.me
+
+# Google Scholar often returns 403 to automated CI checks even when the page is live.
+scholar.google.com/citations

--- a/.lychee/exclude-temporary.txt
+++ b/.lychee/exclude-temporary.txt
@@ -12,7 +12,7 @@ drive.google.com/file/d/0B3O7bgd3mym6N214SWw3eVJCS3M/view
 t.co
 openai.com/index/chatgpt
 www.ieice.org/~nlc
-www.nikkan.co.jp/articles/view/00546182
+www.nikkan.co.jp/articles
 hatenablog-parts.com/embed
 bit.ly/KitadaXColosoJP1
 confit.atlas.jp

--- a/.lychee/exclude-temporary.txt
+++ b/.lychee/exclude-temporary.txt
@@ -12,6 +12,7 @@ drive.google.com/file/d/0B3O7bgd3mym6N214SWw3eVJCS3M/view
 t.co
 openai.com/index/chatgpt
 www.ieice.org/~nlc
+www.nikkan.co.jp/articles/view/00546182
 hatenablog-parts.com/embed
 bit.ly/KitadaXColosoJP1
 confit.atlas.jp

--- a/scripts/prune_lychee_excludes.py
+++ b/scripts/prune_lychee_excludes.py
@@ -197,7 +197,7 @@ def build_pattern_map(patterns: list[PatternEntry], urls: set[str]) -> dict[int,
 
 
 def is_success(statuses: set[int]) -> bool:
-    return any(200 <= status <= 299 or status == 302 for status in statuses)
+    return bool(statuses) and all(200 <= status <= 299 or status == 302 for status in statuses)
 
 
 def write_lines(path: pathlib.Path, lines: list[str]) -> None:
@@ -262,9 +262,8 @@ def main() -> int:
         all_revived = True
         for url in matched:
             statuses = status_map.get(url)
-            if statuses is None:
-                continue
-            if not is_success(statuses):
+            # Require complete successful evidence for every matched URL.
+            if not is_success(statuses or set()):
                 all_revived = False
                 break
         if all_revived:

--- a/tests/test_prune_lychee_excludes.py
+++ b/tests/test_prune_lychee_excludes.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "prune_lychee_excludes.py"
+
+
+def run_prune(tmp_path: Path, *, html: str, exclude_text: str, results: list[dict]) -> subprocess.CompletedProcess[str]:
+    public_dir = tmp_path / "public"
+    public_dir.mkdir()
+    (public_dir / "index.html").write_text(html, encoding="utf-8")
+
+    exclude_path = tmp_path / "exclude-temporary.txt"
+    exclude_path.write_text(exclude_text, encoding="utf-8")
+
+    json_path = tmp_path / "lychee-excludes.json"
+    json_path.write_text(json.dumps(results), encoding="utf-8")
+
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--public-dir",
+            str(public_dir),
+            "--json",
+            str(json_path),
+            "--exclude-file",
+            str(exclude_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_keeps_pattern_when_any_matched_url_is_missing_from_results(tmp_path: Path) -> None:
+    result = run_prune(
+        tmp_path,
+        html="""
+        <a href="https://scholar.google.com/citations?user=GUzGhQIAAAAJ">Kitada</a>
+        <a href="https://scholar.google.com/citations?view_op=top_venues&hl=en&vq=eng_enggeneral">Metrics</a>
+        """,
+        exclude_text="scholar.google.com/citations\n",
+        results=[
+            {
+                "url": "https://scholar.google.com/citations?user=GUzGhQIAAAAJ",
+                "status": {"code": 200},
+            }
+        ],
+    )
+
+    exclude_path = tmp_path / "exclude-temporary.txt"
+    assert exclude_path.read_text(encoding="utf-8") == "scholar.google.com/citations\n"
+    assert result.stdout.strip() == "no change"
+
+
+def test_keeps_pattern_when_a_matched_url_has_mixed_success_and_failure_statuses(tmp_path: Path) -> None:
+    scholar_url = "https://scholar.google.com/citations?user=GUzGhQIAAAAJ"
+    result = run_prune(
+        tmp_path,
+        html=f'<a href="{scholar_url}">Kitada</a>',
+        exclude_text="scholar.google.com/citations\n",
+        results=[
+            {"url": scholar_url, "status": {"code": 200}},
+            {"url": scholar_url, "status": {"code": 403}},
+        ],
+    )
+
+    exclude_path = tmp_path / "exclude-temporary.txt"
+    assert exclude_path.read_text(encoding="utf-8") == "scholar.google.com/citations\n"
+    assert result.stdout.strip() == "no change"
+
+
+def test_prunes_pattern_when_all_matched_urls_have_success_statuses(tmp_path: Path) -> None:
+    result = run_prune(
+        tmp_path,
+        html="""
+        <a href="https://example.com/a">A</a>
+        <a href="https://example.com/b">B</a>
+        """,
+        exclude_text="example.com\n",
+        results=[
+            {"url": "https://example.com/a", "status": {"code": 200}},
+            {"url": "https://example.com/b", "status": {"code": 302}},
+        ],
+    )
+
+    exclude_path = tmp_path / "exclude-temporary.txt"
+    assert exclude_path.read_text(encoding="utf-8") == ""
+    assert result.stdout.strip() == "example.com"


### PR DESCRIPTION
## Summary
- move `scholar.google.com/citations` into the permanent lychee excludes so the prune bot does not remove a CI-flaky domain again
- replace the prune bot's `pull_request_target` + `gh pr merge --auto` flow with a `workflow_run` trigger that waits for `Page Build` to complete successfully
- harden `scripts/prune_lychee_excludes.py` so an entry is pruned only when every matched URL has complete successful lychee evidence
- add regression tests for missing-status and mixed-status prune cases
- temporarily exclude `www.nikkan.co.jp/articles` so current article paths that return 405 to lychee do not fail PR builds

## Root Cause
- PR #341 enabled auto-merge before downstream `Page Build` jobs had started, so the bot PR merged before `check-broken-links` failed
- the scheduled prune flow also relied on an unsafe prune rule: if a matched URL was missing from the lychee JSON, or if one URL had mixed success/failure statuses, the script still treated the pattern as revived and removed it
- Google Scholar URLs are especially prone to this because CI checks against them are flaky and can return 403 under automation
- the latest PR reruns also exposed a separate external-site failure where `www.nikkan.co.jp/articles/...` currently returns 405 to lychee

## Validation
- parsed `.github/workflows/lychee-auto-merge.yml` as YAML locally
- ran `hugo` successfully
- ran `lychee` against the four failing Google Scholar URLs and confirmed they are excluded by the updated config
- ran `uv run --with pytest pytest tests/test_prune_lychee_excludes.py` and confirmed the new regression tests pass
- ran `lychee` against the nikkan article URL and confirmed it is excluded by the updated prefix rule