### PR TITLE
docs(dependabot): clarify semver-major auto-merge policy

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,9 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Enable auto-merge for Dependabot PRs
-        # Auto-merge for all non-major version updates
+        # Auto-merge only non-major Dependabot updates.
+        # Major updates are intentionally left for manual review because they may
+        # introduce breaking changes even when the current checks are green.
         if: ${{ startsWith(steps.metadata.outputs.update-type, 'version-update:') && steps.metadata.outputs.update-type != 'version-update:semver-major' }}
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- clarify that Dependabot auto-merge is intentionally limited to non-major updates
- document that semver-major updates stay manual even when checks are green
- make it easier to diagnose green Dependabot PRs that do not auto-merge

## Testing
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dependabot-auto-merge.yml"); puts "YAML OK"'