### PR TITLE
ci(links): improve broken-link cleanup PR metadata

### DIFF
--- a/.github/workflows/lychee-prune.yml
+++ b/.github/workflows/lychee-prune.yml
@@ -113,15 +113,15 @@ jobs:
 
           branch="chore/prune-lychee-excludes"
           git add .lychee/exclude-temporary.txt
-          git commit -m "chore: prune revived lychee excludes"
+          git commit -m "chore(links): remove recovered URLs from temporary broken-link excludes"
           git push --force-with-lease -u origin "$branch"
 
           if gh pr view --head "$branch" > /dev/null 2>&1; then
             echo "PR already exists for $branch"
           else
             gh pr create \
-              --title "chore: prune revived lychee excludes" \
-              --body "Removed from the temporary excludes because the scheduled check returned 2xx/302." \
+              --title "chore(links): remove recovered URLs from temporary broken-link excludes" \
+              --body "Removed recovered URLs from temporary broken-link excludes because the scheduled check returned 2xx/302." \
               --base main \
               --head "$branch"
           fi

--- a/.github/workflows/lychee-prune.yml
+++ b/.github/workflows/lychee-prune.yml
@@ -96,13 +96,21 @@ jobs:
 
       - name: Prune revived excludes
         if: steps.temp.outputs.has_items == 'true' && steps.prepare.outputs.has_links == 'true'
-        run: python scripts/prune_lychee_excludes.py --public-dir "${{ vars.ARTIFACT_PATH }}" --json lychee-excludes.json --exclude-file .lychee/exclude-temporary.txt
+        run: |
+          python scripts/prune_lychee_excludes.py \
+            --public-dir "${{ vars.ARTIFACT_PATH }}" \
+            --json lychee-excludes.json \
+            --exclude-file .lychee/exclude-temporary.txt \
+            --pr-body-output lychee-pr-body.md
 
       - name: Create pull request
         if: steps.temp.outputs.has_items == 'true' && steps.prepare.outputs.has_links == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          pr_title="chore(links): remove recovered URLs from temporary broken-link excludes"
+          pr_body_file="lychee-pr-body.md"
+
           if git diff --quiet -- .lychee/exclude-temporary.txt; then
             echo "no changes"
             exit 0
@@ -113,15 +121,19 @@ jobs:
 
           branch="chore/prune-lychee-excludes"
           git add .lychee/exclude-temporary.txt
-          git commit -m "chore(links): remove recovered URLs from temporary broken-link excludes"
+          git commit -m "${pr_title}"
           git push --force-with-lease -u origin "$branch"
 
           if gh pr view --head "$branch" > /dev/null 2>&1; then
-            echo "PR already exists for $branch"
+            pr_number="$(gh pr view --head "$branch" --json number --jq '.number')"
+            gh pr edit "$pr_number" \
+              --title "${pr_title}" \
+              --body "$(cat "$pr_body_file")"
+            echo "Updated PR #$pr_number for $branch"
           else
             gh pr create \
-              --title "chore(links): remove recovered URLs from temporary broken-link excludes" \
-              --body "Removed recovered URLs from temporary broken-link excludes because the scheduled check returned 2xx/302." \
+              --title "${pr_title}" \
+              --body-file "$pr_body_file" \
               --base main \
               --head "$branch"
           fi

--- a/scripts/prune_lychee_excludes.py
+++ b/scripts/prune_lychee_excludes.py
@@ -58,6 +58,12 @@ def parse_args() -> argparse.Namespace:
         help="Write matched URLs for lychee input",
     )
     parser.add_argument(
+        "--pr-body-output",
+        dest="pr_body_output",
+        type=pathlib.Path,
+        help="Write a markdown PR body describing removed patterns and recovered URLs",
+    )
+    parser.add_argument(
         "--prepare",
         action="store_true",
         help="Only generate the links output and exit",
@@ -217,6 +223,21 @@ def write_links(path: pathlib.Path, urls: set[str]) -> None:
         handle.write(content)
 
 
+def format_pr_body(removed_patterns: list[tuple[str, list[str]]]) -> str:
+    lines = [
+        "Removed recovered URLs from temporary broken-link excludes because the scheduled check returned 2xx/302.",
+        "",
+        "## Recovered URLs",
+        "",
+    ]
+    for pattern, urls in removed_patterns:
+        lines.append(f"### `{pattern}`")
+        for url in urls:
+            lines.append(f"- `{url}`")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
 def main() -> int:
     args = parse_args()
 
@@ -254,6 +275,7 @@ def main() -> int:
     status_map = collect_status_map(data)
     removed_indices: set[int] = set()
     removed_lines: list[str] = []
+    removed_patterns: list[tuple[str, list[str]]] = []
 
     for pattern in patterns:
         matched = pattern_map.get(pattern.index, set())
@@ -269,10 +291,14 @@ def main() -> int:
         if all_revived:
             removed_indices.add(pattern.index)
             removed_lines.append(pattern.raw_line)
+            removed_patterns.append((pattern.raw_line, sorted(matched)))
 
     if not removed_lines:
         print("no change")
         return 0
+
+    if args.pr_body_output is not None:
+        args.pr_body_output.write_text(format_pr_body(removed_patterns), encoding="utf-8")
 
     if args.dry_run:
         for line in removed_lines:

--- a/tests/test_prune_lychee_excludes.py
+++ b/tests/test_prune_lychee_excludes.py
@@ -10,7 +10,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "prune_lychee_excludes.py"
 
 
-def run_prune(tmp_path: Path, *, html: str, exclude_text: str, results: list[dict]) -> subprocess.CompletedProcess[str]:
+def run_prune(
+    tmp_path: Path,
+    *,
+    html: str,
+    exclude_text: str,
+    results: list[dict],
+    pr_body_output: str | None = None,
+) -> subprocess.CompletedProcess[str]:
     public_dir = tmp_path / "public"
     public_dir.mkdir()
     (public_dir / "index.html").write_text(html, encoding="utf-8")
@@ -21,17 +28,21 @@ def run_prune(tmp_path: Path, *, html: str, exclude_text: str, results: list[dic
     json_path = tmp_path / "lychee-excludes.json"
     json_path.write_text(json.dumps(results), encoding="utf-8")
 
+    command = [
+        sys.executable,
+        str(SCRIPT_PATH),
+        "--public-dir",
+        str(public_dir),
+        "--json",
+        str(json_path),
+        "--exclude-file",
+        str(exclude_path),
+    ]
+    if pr_body_output is not None:
+        command.extend(["--pr-body-output", str(tmp_path / pr_body_output)])
+
     return subprocess.run(
-        [
-            sys.executable,
-            str(SCRIPT_PATH),
-            "--public-dir",
-            str(public_dir),
-            "--json",
-            str(json_path),
-            "--exclude-file",
-            str(exclude_path),
-        ],
+        command,
         check=True,
         capture_output=True,
         text=True,
@@ -92,4 +103,32 @@ def test_prunes_pattern_when_all_matched_urls_have_success_statuses(tmp_path: Pa
 
     exclude_path = tmp_path / "exclude-temporary.txt"
     assert exclude_path.read_text(encoding="utf-8") == ""
+    assert result.stdout.strip() == "example.com"
+
+
+def test_writes_pr_body_with_removed_patterns_and_recovered_urls(tmp_path: Path) -> None:
+    result = run_prune(
+        tmp_path,
+        html="""
+        <a href="https://example.com/a">A</a>
+        <a href="https://example.com/b">B</a>
+        """,
+        exclude_text="example.com\n",
+        results=[
+            {"url": "https://example.com/a", "status": {"code": 200}},
+            {"url": "https://example.com/b", "status": {"code": 302}},
+        ],
+        pr_body_output="pr-body.md",
+    )
+
+    pr_body_path = tmp_path / "pr-body.md"
+    assert pr_body_path.read_text(encoding="utf-8") == (
+        "Removed recovered URLs from temporary broken-link excludes because the scheduled check returned 2xx/302.\n"
+        "\n"
+        "## Recovered URLs\n"
+        "\n"
+        "### `example.com`\n"
+        "- `https://example.com/a`\n"
+        "- `https://example.com/b`\n"
+    )
     assert result.stdout.strip() == "example.com"


### PR DESCRIPTION
## Summary
- rename the generated commit subject and PR title for broken-link exclude cleanup PRs
- generate a markdown PR body that lists recovered URLs removed from temporary broken-link excludes
- keep the bot PR title and body in sync when an existing prune branch is reused
