### PR TITLE
Add conference news updates and align generation rules

### DIFF
--- a/.agents/skills/hugo-conference-news-sync/SKILL.md
+++ b/.agents/skills/hugo-conference-news-sync/SKILL.md
@@ -30,9 +30,12 @@ uv run --with ruamel.yaml python scripts/sync_conference_news.py --repo-root <re
 ```
 - Default behavior:
 - Add missing conference tags and conference-year tags to publication entries.
-- Create news files with `draft: false` by default under `content/news/<conference>-<year>-presentations/index.md`.
-- Initialize each new news file with `make news name="<conference>-<year>-presentations"` before writing final content.
-- Set news tags to `["News", "<CONF>", "<CONF><YEAR>"]`.
+- Classify each publication group from publication `tags`:
+- `Domestic Conference` -> presentation-style news under `content/news/<conference>-<year>-presentations/index.md`
+- `International Conference` or `International Publication` -> acceptance-style news under `content/news/acceptance-to-<conference-label>/index.md`
+- Initialize each new news file with `make news name="<generated-slug>"` before writing final content.
+- For presentation-style news, set tags to `["News", "<CONF>", "<CONF><YEAR>"]`.
+- For acceptance-style news, set tags to `["News"]`.
 - Use `--draft` only when intentionally creating unpublished drafts.
 - Set `date` and `lastmod` to the earliest publication `date` in the conference-year group.
 - Skip groups already referenced by existing news publication links.
@@ -46,8 +49,9 @@ uv run --with ruamel.yaml python scripts/sync_conference_news.py --repo-root <re
 - Conference/year extraction from `publication_short`:
 - Handles `CONF 2026`, `CONF2026`, `CONF-CONF2026`, and `CONF` + year from `date`.
 - Removes award annotations like `*（...）*`.
-- Removes trailing `SRW`.
+- Uses stripped base venue names for conference tag backfill.
 - Maps `NLP` to `ANLP`.
+- Keeps venue modifiers such as `SRW` and `Findings of` in generated international news labels/slugs.
 
 - Publication filtering:
 - Skip `publication_types` containing `thesis` or `article-journal`.
@@ -57,8 +61,9 @@ uv run --with ruamel.yaml python scripts/sync_conference_news.py --repo-root <re
 - Ensure `<CONF>` and `<CONF><YEAR>` are present in `tags`.
 - Append only missing values.
 
-- News tags:
-- Emit `tags` as `News` + conference name + conference-year tag.
+- News style:
+- Domestic conference groups generate `Our Presentations at ...` / `We will present ...`.
+- International conference groups generate `Accepted our paper(s) to ...` / `The following paper(s) have/has been accepted ...`.
 
 - Duplicate prevention:
 - Parse existing `content/news/*/index.md` and collect `/publication/<slug>` links.
@@ -89,11 +94,12 @@ uv run --with ruamel.yaml python scripts/sync_conference_news.py --repo-root <re
 ## Expected Outputs
 
 - Updated publication files with missing conference tags.
-- New news files grouped by conference-year, with conference-date-aligned `date`/`lastmod` and conference tags.
+- New news files grouped by venue/year, with domestic groups using `*-presentations` and international groups using `acceptance-to-*`.
 - Summary logs for modified files, created groups, and skipped groups.
 
 ## Post-Processing Checklist
 
 - Confirm `hugo build` passes.
 - Confirm generated bullets are link-only.
+- Confirm the generated slug/title/body follow the domestic/international convention.
 - When needed, regenerate with `--draft` for unpublished staging.

--- a/content/news/acceptance-to-acl2026srw/index.md
+++ b/content/news/acceptance-to-acl2026srw/index.md
@@ -1,11 +1,11 @@
 ---
 # Documentation: https://docs.hugoblox.com/managing-content/
 
-title: "Our Presentations at ACL 2026 SRW"
+title: "Accepted our papers to ACL2026 SRW"
 subtitle: ""
 summary: ""
 authors: ["Shunsuke Kitada"]
-tags: ["News", "ACL", "ACL2026"]
+tags: ["News"]
 categories: ["News"]
 date: 2026-05-05T00:00:00+09:00
 lastmod: 2026-05-05T00:00:00+09:00
@@ -28,7 +28,7 @@ image:
 projects: []
 ---
 
-We will present the following papers at the [ACL 2026 Student Research Workshop (SRW)](https://acl2026-srw.github.io/):
+The following papers have been accepted to the [ACL 2026 Student Research Workshop (SRW)](https://acl2026-srw.github.io/).
 
 - Ryuhei Miyazato, Shunsuke Kitada, and Kei Harada. ["EnsemHalDet: Robust VLM Hallucination Detection via Ensemble of Internal State Detectors"](/publication/miyazato2026ensemhaldet).
 - Michito Takeshita, Takuro Kawada, Takumi Ohashi, Shunsuke Kitada, and Hitoshi Iyatomi. ["A11y-Compressor: A Framework for Enhancing the Efficiency of GUI Agent Observations through Visual Context Reconstruction and Redundancy Reduction"](/publication/takeshita2026a11ycompressor).

--- a/content/news/acceptance-to-findings-of-cvpr-2026/index.md
+++ b/content/news/acceptance-to-findings-of-cvpr-2026/index.md
@@ -1,11 +1,11 @@
 ---
 # Documentation: https://docs.hugoblox.com/managing-content/
 
-title: "Our Presentations at Findings of CVPR 2026"
+title: "Accepted our papers to Findings of CVPR 2026"
 subtitle: ""
 summary: ""
 authors: ["Shunsuke Kitada"]
-tags: ["News", "CVPR", "CVPR2026"]
+tags: ["News"]
 categories: ["News"]
 date: 2026-02-21T00:00:00+00:00
 lastmod: 2026-02-21T00:00:00+00:00
@@ -26,9 +26,12 @@ image:
 #   E.g. `projects = ["internal-project"]` references `content/project/deep-learning/index.md`.
 #   Otherwise, set `projects = []`.
 projects: []
+
+aliases:
+  - /news/cvpr-2026-presentations/
 ---
 
-We will present the following papers at the CVPR 2026 Findings track:
+The following papers have been accepted to the Findings of CVPR 2026:
 
 - Takuro Kawada, Shunsuke Kitada, Sota Nemoto, Hitoshi Iyatomi. ["SciGA: A Comprehensive Dataset for Designing Graphical Abstracts in Academic Papers"](/publication/kawada2025sciga).
 - Daichi Nagai, Ryugo Morita, Shunsuke Kitada, Hitoshi Iyatomi. ["TAUE: Training-free Noise Transplant and Cultivation Diffusion Model"](/publication/nagai2025taue).

--- a/content/news/acl2026-srw-presentations/index.md
+++ b/content/news/acl2026-srw-presentations/index.md
@@ -1,0 +1,34 @@
+---
+# Documentation: https://docs.hugoblox.com/managing-content/
+
+title: "Our Presentations at ACL 2026 SRW"
+subtitle: ""
+summary: ""
+authors: ["Shunsuke Kitada"]
+tags: ["News", "ACL", "ACL2026"]
+categories: ["News"]
+date: 2026-05-05T00:00:00+09:00
+lastmod: 2026-05-05T00:00:00+09:00
+featured: false
+draft: false
+
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+# Focal points: Smart, Center, TopLeft, Top, TopRight, Left, Right, BottomLeft, Bottom, BottomRight.
+image:
+  caption: ""
+  focal_point: ""
+  preview_only: false
+
+# Projects (optional).
+#   Associate this post with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `projects = ["internal-project"]` references `content/project/deep-learning/index.md`.
+#   Otherwise, set `projects = []`.
+projects: []
+---
+
+We will present the following papers at the [ACL 2026 Student Research Workshop (SRW)](https://acl2026-srw.github.io/):
+
+- Ryuhei Miyazato, Shunsuke Kitada, and Kei Harada. ["EnsemHalDet: Robust VLM Hallucination Detection via Ensemble of Internal State Detectors"](/publication/miyazato2026ensemhaldet).
+- Michito Takeshita, Takuro Kawada, Takumi Ohashi, Shunsuke Kitada, and Hitoshi Iyatomi. ["A11y-Compressor: A Framework for Enhancing the Efficiency of GUI Agent Observations through Visual Context Reconstruction and Redundancy Reduction"](/publication/takeshita2026a11ycompressor).

--- a/content/publication/miyazato2026ensemhaldet/index.md
+++ b/content/publication/miyazato2026ensemhaldet/index.md
@@ -1,0 +1,80 @@
+---
+# Documentation: https://docs.hugoblox.com/managing-content/
+
+title: "EnsemHalDet: Robust VLM Hallucination Detection via Ensemble of Internal State Detectors"
+authors: ["Ryuhei Miyazato", "Shunsuke Kitada", "Kei Harada"]
+date: 2026-04-03T00:00:00+09:00
+doi: ""
+
+# Schedule page publish date (NOT publication's date).
+publishDate: 2026-04-03T00:00:00+09:00
+
+# Publication type.
+# Legend: 0 = Uncategorized; 1 = Conference paper; 2 = Journal article;
+# 3 = Preprint / Working Paper; 4 = Report; 5 = Book; 6 = Book section;
+# 7 = Thesis; 8 = Patent
+publication_types: ["paper-conference"]
+
+# Publication name and optional abbreviated publication name.
+publication: "Proc. of the 64th Annual Meeting of the Association for Computational Linguistics: Student Research Workshop"
+publication_short: "ACL2026 SRW"
+
+abstract: "Vision-Language Models (VLMs) excel at multimodal tasks, but they remain vulnerable to hallucinations that are factually incorrect or ungrounded in the input image. Recent work suggests that hallucination detection using internal representations is more efficient and accurate than approaches that rely solely on model outputs. However, existing internal-representation-based methods typically rely on a single representation or detector, limiting their ability to capture diverse hallucination signals. In this paper, we propose EnsemHalDet, an ensemble-based hallucination detection framework that leverages multiple internal representations of VLMs, including attention outputs and hidden states. EnsemHalDet trains independent detectors for each representation and combines them through ensemble learning. Experimental results across multiple VQA datasets and VLMs show that EnsemHalDet consistently outperforms prior methods and single-detector models in terms of AUC. These results demonstrate that ensembling diverse internal signals significantly improves robustness in multimodal hallucination detection."
+
+# Summary. An optional shortened abstract.
+summary: "Accepted to ACL SRW 2026"
+
+tags:
+- "International Conference"
+- "Refereed"
+- "International Publication"
+- "Natural Language Processing"
+- "Vision & Language"
+- "Hallucination Detection"
+- ACL
+- ACL2026
+categories:
+- "Vision & Language"
+- "Hallucination Detection"
+- "Multimodal Large Language Models"
+featured: false
+
+# Custom links (optional).
+#   Uncomment and edit lines below to show custom links.
+links:
+- name: Preprint
+  url: https://arxiv.org/abs/2604.02784
+  icon_pack: ai
+  icon: arxiv
+
+url_pdf:
+url_code:
+url_dataset:
+url_poster:
+url_project:
+url_slides:
+url_source:
+url_video:
+
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+# Focal points: Smart, Center, TopLeft, Top, TopRight, Left, Right, BottomLeft, Bottom, BottomRight.
+image:
+  caption: ""
+  focal_point: ""
+  preview_only: true
+
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/miyazato2026ensemhaldet/index.md
+++ b/content/publication/miyazato2026ensemhaldet/index.md
@@ -22,17 +22,16 @@ publication_short: "ACL2026 SRW"
 abstract: "Vision-Language Models (VLMs) excel at multimodal tasks, but they remain vulnerable to hallucinations that are factually incorrect or ungrounded in the input image. Recent work suggests that hallucination detection using internal representations is more efficient and accurate than approaches that rely solely on model outputs. However, existing internal-representation-based methods typically rely on a single representation or detector, limiting their ability to capture diverse hallucination signals. In this paper, we propose EnsemHalDet, an ensemble-based hallucination detection framework that leverages multiple internal representations of VLMs, including attention outputs and hidden states. EnsemHalDet trains independent detectors for each representation and combines them through ensemble learning. Experimental results across multiple VQA datasets and VLMs show that EnsemHalDet consistently outperforms prior methods and single-detector models in terms of AUC. These results demonstrate that ensembling diverse internal signals significantly improves robustness in multimodal hallucination detection."
 
 # Summary. An optional shortened abstract.
-summary: "Accepted to ACL SRW 2026"
+summary: "Proc. ACL SRW 2026"
 
 tags:
-- "International Conference"
-- "Refereed"
 - "International Publication"
+- "Refereed"
 - "Natural Language Processing"
-- "Vision & Language"
-- "Hallucination Detection"
 - ACL
 - ACL2026
+- "Vision & Language"
+- "Hallucination Detection"
 categories:
 - "Vision & Language"
 - "Hallucination Detection"
@@ -78,3 +77,5 @@ projects: []
 #   Otherwise, set `slides: ""`.
 slides: ""
 ---
+
+{{< blogcard url="https://arxiv.org/abs/2604.02784" >}}

--- a/content/publication/takeshita2026a11ycompressor/index.md
+++ b/content/publication/takeshita2026a11ycompressor/index.md
@@ -1,0 +1,82 @@
+---
+# Documentation: https://docs.hugoblox.com/managing-content/
+
+title: "A11y-Compressor: A Framework for Enhancing the Efficiency of GUI Agent Observations through Visual Context Reconstruction and Redundancy Reduction"
+authors: ["Michito Takeshita", "Takuro Kawada", "Takumi Ohashi", "Shunsuke Kitada", "Hitoshi Iyatomi"]
+date: 2026-05-01T00:00:00+09:00
+doi: ""
+
+# Schedule page publish date (NOT publication's date).
+publishDate: 2026-05-01T00:00:00+09:00
+
+# Publication type.
+# Legend: 0 = Uncategorized; 1 = Conference paper; 2 = Journal article;
+# 3 = Preprint / Working Paper; 4 = Report; 5 = Book; 6 = Book section;
+# 7 = Thesis; 8 = Patent
+publication_types: ["paper-conference"]
+
+# Publication name and optional abbreviated publication name.
+publication: "Proc. of the 64th Annual Meeting of the Association for Computational Linguistics: Student Research Workshop"
+publication_short: "ACL2026 SRW"
+
+abstract: "AI agents that interact with graphical user interfaces (GUIs) require effective observation representations for reliable grounding. The accessibility tree is a commonly used text-based format that encodes UI element attributes, but it suffers from redundancy and lacks structural information such as spatial relationships among elements. We propose A11y-Compressor, a framework that transforms linearized accessibility trees into compact and structured representations. Our implementation, Compressed-a11y, applies a lightweight and structured transformation pipeline with modal detection, redundancy reduction, and semantic structuring. Experiments on the OSWorld benchmark show that Compressed-a11y reduces input tokens to 22% of the original while improving task success rates by 5.1 percentage points on average."
+
+# Summary. An optional shortened abstract.
+summary: "Accepted to ACL SRW 2026"
+
+tags:
+- "International Conference"
+- "Refereed"
+- "International Publication"
+- "Natural Language Processing"
+- "AI Agent"
+- "Computer Use"
+- "GUI Agent"
+- "Accessibility Tree"
+- ACL
+- ACL2026
+categories:
+- "Natural Language Processing"
+- "Vision & Language"
+- "AI Agent"
+featured: false
+
+# Custom links (optional).
+#   Uncomment and edit lines below to show custom links.
+links:
+- name: Preprint
+  url: https://arxiv.org/abs/2605.00551
+  icon_pack: ai
+  icon: arxiv
+
+url_pdf:
+url_code:
+url_dataset:
+url_poster:
+url_project: https://iyatomilab.github.io/a11y-compressor/
+url_slides:
+url_source:
+url_video:
+
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+# Focal points: Smart, Center, TopLeft, Top, TopRight, Left, Right, BottomLeft, Bottom, BottomRight.
+image:
+  caption: ""
+  focal_point: ""
+  preview_only: true
+
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/takeshita2026a11ycompressor/index.md
+++ b/content/publication/takeshita2026a11ycompressor/index.md
@@ -22,19 +22,18 @@ publication_short: "ACL2026 SRW"
 abstract: "AI agents that interact with graphical user interfaces (GUIs) require effective observation representations for reliable grounding. The accessibility tree is a commonly used text-based format that encodes UI element attributes, but it suffers from redundancy and lacks structural information such as spatial relationships among elements. We propose A11y-Compressor, a framework that transforms linearized accessibility trees into compact and structured representations. Our implementation, Compressed-a11y, applies a lightweight and structured transformation pipeline with modal detection, redundancy reduction, and semantic structuring. Experiments on the OSWorld benchmark show that Compressed-a11y reduces input tokens to 22% of the original while improving task success rates by 5.1 percentage points on average."
 
 # Summary. An optional shortened abstract.
-summary: "Accepted to ACL SRW 2026"
+summary: "Proc. ACL SRW 2026"
 
 tags:
-- "International Conference"
-- "Refereed"
 - "International Publication"
+- "Refereed"
 - "Natural Language Processing"
+- ACL
+- ACL2026
 - "AI Agent"
 - "Computer Use"
 - "GUI Agent"
 - "Accessibility Tree"
-- ACL
-- ACL2026
 categories:
 - "Natural Language Processing"
 - "Vision & Language"
@@ -80,3 +79,5 @@ projects: []
 #   Otherwise, set `slides: ""`.
 slides: ""
 ---
+
+{{< blogcard url="https://arxiv.org/abs/2605.00551" >}}

--- a/scripts/sync_conference_news.py
+++ b/scripts/sync_conference_news.py
@@ -18,6 +18,10 @@ from ruamel.yaml import YAML
 CONF_NAME_MAP = {
     "NLP": "ANLP",
 }
+NEWS_KIND_PRESENTATIONS = "presentations"
+NEWS_KIND_ACCEPTANCE = "acceptance"
+DOMESTIC_CONFERENCE_TAG = "Domestic Conference"
+INTERNATIONAL_NEWS_TAGS = {"International Conference", "International Publication"}
 
 SKIP_PUBLICATION_TYPES = {"thesis", "article-journal"}
 JOURNAL_LIKE_SHORTS = {
@@ -35,19 +39,23 @@ class ConferenceKey:
 
     name: str
     year: str
+    display_label: str
+    news_kind: str
 
     @property
     def label(self) -> str:
-        """Return display label such as `ANLP 2026`."""
+        """Return display label such as `ANLP 2026` or `ACL2026 SRW`."""
 
-        return f"{self.name} {self.year}"
+        return self.display_label
 
     @property
     def slug(self) -> str:
-        """Return news slug such as `anlp-2026-presentations`."""
+        """Return news slug based on the domestic/international convention."""
 
-        base = re.sub(r"[^a-z0-9]+", "-", self.name.lower()).strip("-")
-        return f"{base}-{self.year}-presentations"
+        base = slugify_label(self.display_label)
+        if self.news_kind == NEWS_KIND_ACCEPTANCE:
+            return f"acceptance-to-{base}"
+        return f"{base}-presentations"
 
 
 @dataclass
@@ -60,6 +68,12 @@ class Publication:
     authors: list[str]
     date: str
     conf: ConferenceKey
+
+
+def slugify_label(value: str) -> str:
+    """Convert a human-readable label into a stable slug fragment."""
+
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
 
 
 class FrontmatterIO:
@@ -96,23 +110,54 @@ class FrontmatterIO:
         path.write_text(f"---\n{fm}\n---{body}", encoding="utf-8")
 
 
-def normalize_publication_short(value: str) -> str:
-    """Normalize `publication_short` by stripping decorations and SRW suffix."""
+def strip_publication_short_decorations(value: str) -> str:
+    """Remove award-like decorations while keeping the visible venue label."""
 
     normalized = value.strip()
-    normalized = re.sub(r"^(?i:findings of)\s+", "", normalized)
     normalized = re.sub(r"\s*\*（[^）]*）\*", "", normalized)
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized.strip()
+
+
+def build_display_label(publication_short: str) -> str:
+    """Build the visible news label while preserving venue modifiers like `SRW`."""
+
+    display = strip_publication_short_decorations(publication_short)
+    display = re.sub(r"^NLP(?=(?:\s|\d))", "ANLP", display)
+    return display
+
+
+def normalize_publication_short(value: str) -> str:
+    """Normalize `publication_short` for base conference/year parsing."""
+
+    normalized = strip_publication_short_decorations(value)
+    normalized = re.sub(r"^(?i:findings of)\s+", "", normalized)
     normalized = re.sub(r"\s+SRW$", "", normalized)
     return normalized.strip()
 
 
-def parse_conf_key(publication_short: str, date_value: object) -> ConferenceKey | None:
-    """Parse conference name/year from `publication_short` and fallback date."""
+def infer_news_kind(tags: object) -> str:
+    """Decide whether a news post should use acceptance or presentation wording."""
+
+    normalized_tags = {str(tag) for tag in (tags or [])}
+    if DOMESTIC_CONFERENCE_TAG in normalized_tags:
+        return NEWS_KIND_PRESENTATIONS
+    if normalized_tags & INTERNATIONAL_NEWS_TAGS:
+        return NEWS_KIND_ACCEPTANCE
+    return NEWS_KIND_PRESENTATIONS
+
+
+def parse_conf_key(
+    publication_short: str, date_value: object, tags: object
+) -> ConferenceKey | None:
+    """Parse conference metadata from `publication_short`, tags, and fallback date."""
 
     short = normalize_publication_short(publication_short)
     if not short or short in JOURNAL_LIKE_SHORTS:
         return None
 
+    display_label = build_display_label(publication_short)
+    news_kind = infer_news_kind(tags)
     patterns = (
         r"^([A-Z]+)\s+(\d{4})$",
         r"^([A-Z]+[A-Z-]*)(\d{4})$",
@@ -122,7 +167,7 @@ def parse_conf_key(publication_short: str, date_value: object) -> ConferenceKey 
         match = re.match(pattern, short)
         if match:
             conf = CONF_NAME_MAP.get(match.group(1), match.group(1))
-            return ConferenceKey(conf, match.group(2))
+            return ConferenceKey(conf, match.group(2), display_label, news_kind)
 
     only_name = re.match(r"^([A-Z]+)$", short)
     if only_name:
@@ -130,7 +175,7 @@ def parse_conf_key(publication_short: str, date_value: object) -> ConferenceKey 
         if not year_match:
             return None
         conf = CONF_NAME_MAP.get(only_name.group(1), only_name.group(1))
-        return ConferenceKey(conf, year_match.group(1))
+        return ConferenceKey(conf, year_match.group(1), display_label, news_kind)
 
     return None
 
@@ -162,7 +207,11 @@ def parse_publications(publication_dir: Path, io: FrontmatterIO) -> list[Publica
         if not publication_short:
             continue
 
-        conf = parse_conf_key(str(publication_short), frontmatter.get("date"))
+        conf = parse_conf_key(
+            str(publication_short),
+            frontmatter.get("date"),
+            frontmatter.get("tags") or [],
+        )
         if not conf:
             continue
 
@@ -222,15 +271,28 @@ def render_news_markdown(
 
     paper_word = "paper" if len(publications) == 1 else "papers"
     conf_year_tag = f"{conf.name}{conf.year}"
+    if conf.news_kind == NEWS_KIND_ACCEPTANCE:
+        title = f"Accepted our {paper_word} to {conf.label}"
+        body = (
+            f"The following {paper_word} has been accepted to {conf.label}:"
+            if len(publications) == 1
+            else f"The following {paper_word} have been accepted to {conf.label}:"
+        )
+        news_tags = 'tags: ["News"]'
+    else:
+        title = f"Our Presentations at {conf.label}"
+        body = f"We will present the following {paper_word} at {conf.label}:"
+        news_tags = f'tags: ["News", "{conf.name}", "{conf_year_tag}"]'
+
     lines: list[str] = [
         "---",
         "# Documentation: https://docs.hugoblox.com/managing-content/",
         "",
-        f'title: "Our Presentations at {conf.label}"',
+        f'title: "{title}"',
         'subtitle: ""',
         'summary: ""',
         f'authors: ["{author}"]',
-        f'tags: ["News", "{conf.name}", "{conf_year_tag}"]',
+        news_tags,
         'categories: ["News"]',
         f"date: {conference_date}",
         f"lastmod: {conference_date}",
@@ -253,7 +315,7 @@ def render_news_markdown(
         "projects: []",
         "---",
         "",
-        f"We will present the following {paper_word} at {conf.label}:",
+        body,
         "",
     ]
     for publication in publications:


### PR DESCRIPTION
## Summary
- add ACL 2026 SRW acceptance news and publication entries
- align the new ACL SRW publication pages with the existing ACL SRW publication style
- convert the existing Findings of CVPR 2026 news post to the international-conference acceptance convention while keeping the old URL via an alias
- update `scripts/sync_conference_news.py` to generate acceptance-style news for international conferences and presentation-style news for domestic conferences
- update the `hugo-conference-news-sync` skill so the documented workflow matches the script behavior

## Testing
- `git diff --check`
- `hugo build`
