### PR TITLE
Backfill conference tags for existing acceptance-style news

### DIFF
--- a/.agents/skills/hugo-conference-news-sync/SKILL.md
+++ b/.agents/skills/hugo-conference-news-sync/SKILL.md
@@ -30,6 +30,7 @@ uv run --with ruamel.yaml python scripts/sync_conference_news.py --repo-root <re
 ```
 - Default behavior:
 - Add missing conference tags and conference-year tags to publication entries.
+- Backfill missing conference tags on existing acceptance-style conference news when the venue/year can be inferred from linked publications or the news title.
 - Classify each publication group from publication `tags`:
 - `Domestic Conference` -> presentation-style news under `content/news/<conference>-<year>-presentations/index.md`
 - `International Conference` or `International Publication` -> acceptance-style news under `content/news/acceptance-to-<conference-label>/index.md`
@@ -59,6 +60,12 @@ uv run --with ruamel.yaml python scripts/sync_conference_news.py --repo-root <re
 - Tag backfill:
 - Ensure `<CONF>` and `<CONF><YEAR>` are present in `tags`.
 - Append only missing values.
+
+- Existing news tag backfill:
+- Scan existing `content/news/acceptance-to-*/index.md`.
+- Prefer linked publication metadata to infer `<CONF>` / `<CONF><YEAR>`.
+- Fall back to the news title when linked publications are insufficient.
+- Skip journal-style news where no conference-year can be inferred.
 
 - News style:
 - Domestic conference groups generate `Our Presentations at ...` / `We will present ...`.

--- a/content/news/acceptance-to-aacl2020srw/index.md
+++ b/content/news/acceptance-to-aacl2020srw/index.md
@@ -5,7 +5,7 @@ title: "Accepted our paper to AACL-IJCNLP2020 SRW"
 subtitle: ""
 summary: ""
 authors: ["Takumi Aoki", "Shunsuke Kitada", "Hitoshi Iyatomi"]
-tags: ["News"]
+tags: ["News", AACL-IJCNLP, AACL-IJCNLP2020]
 categories: ["News"]
 date: 2020-10-24T00:00:00+09:00
 lastmod: 2022-12-27T22:08:15+09:00

--- a/content/news/acceptance-to-acl2020srw/index.md
+++ b/content/news/acceptance-to-acl2020srw/index.md
@@ -5,7 +5,7 @@ title: "Accepted our paper to ACL2020 SRW"
 subtitle: ""
 summary: ""
 authors: ["Mahmoud Daif", "Shunsuke Kitada", "Hitoshi Iyatomi"]
-tags: ["News"]
+tags: ["News", ACL, ACL2020]
 categories: ["News"]
 date: 2020-04-18T00:00:00+09:00
 lastmod: 2022-12-27T22:13:04+09:00

--- a/content/news/acceptance-to-cikm2022/index.md
+++ b/content/news/acceptance-to-cikm2022/index.md
@@ -5,7 +5,7 @@ title: "Accepted our paper to ACM CIKM2022"
 subtitle: ""
 summary: ""
 authors: ["Tsubasa Nakagawa", "Shunsuke Kitada", "Hitoshi Iyatomi"]
-tags: ["News"]
+tags: ["News", CIKM, CIKM2022]
 categories: ["News"]
 date: 2022-08-01T00:00:00+09:00
 lastmod: 2022-08-01T00:00:00+09:00

--- a/content/news/acceptance-to-eccv2024/index.md
+++ b/content/news/acceptance-to-eccv2024/index.md
@@ -5,7 +5,7 @@ title: "Accepted our paper to ECCV2024"
 subtitle: ""
 summary: ""
 authors: ["Shoma Iwai", "Atsuki Osanai", "Shunsuke Kitada", "Shinichiro Omachi"]
-tags: ["News"]
+tags: ["News", ECCV, ECCV2024]
 categories: ["News"]
 date: 2024-07-01T00:00:00+09:00
 lastmod: 2024-07-01T08:00:00+00:00

--- a/content/news/acceptance-to-honet2022/index.md
+++ b/content/news/acceptance-to-honet2022/index.md
@@ -5,7 +5,7 @@ title: "Accepted our paper to IEEE HONET2022"
 subtitle: ""
 summary: ""
 authors: ["Ohata Kazuya", "Shunsuke Kitada", "Hitoshi Iyatomi"]
-tags: ["News"]
+tags: ["News", HONET, HONET2022]
 categories: ["News"]
 date: 2022-10-17T00:00:00+09:00
 lastmod: 2022-10-17T00:00:00+09:00

--- a/content/news/acceptance-to-iccv2025-found-workshop/index.md
+++ b/content/news/acceptance-to-iccv2025-found-workshop/index.md
@@ -5,7 +5,7 @@ title: "Accepted our Workshop Proposal on Foundation Data to ICCV 2025"
 subtitle: ""
 summary: ""
 authors: ["Yoshihiro Fukuhara", "Hirokatsu Kataoka", "Püren Güler", "Shunsuke Kitada", "Xavier Boix", "Dan Hendrycks", "Keisuke Tateno", "Shinichi Mae", "Tatsuya Komatsu", "Nishant Rai", "Ryo Nakamura", "Risa Shinoda", "Takahiro Itazuri", "Yoshiki Kubotani", "Guarin Flück", "Wadim Kehl", "Kazuki Kozuka"]
-tags: ["News"]
+tags: ["News", ICCV, ICCV2025]
 categories: ["News"]
 date: 2025-04-18T00:00:00+00:00
 lastmod: 2025-04-18T00:00:00+00:00

--- a/content/news/acceptance-to-iclr2024-pm4lrs/index.md
+++ b/content/news/acceptance-to-iclr2024-pm4lrs/index.md
@@ -5,7 +5,7 @@ title: "Accepted our paper to PM4LRS workshop at ICLR2024"
 subtitle: ""
 summary: ""
 authors: ["Sota Nemoto", "Shunsuke Kitada", "Hitoshi Iyatomi"]
-tags: ["News"]
+tags: ["News", ICLR, ICLR2024]
 categories: ["News"]
 date: 2024-03-06T00:00:00+09:00
 lastmod: 2024-03-06T00:00:00+09:00

--- a/content/news/acceptance-to-ieee-aipr2018/index.md
+++ b/content/news/acceptance-to-ieee-aipr2018/index.md
@@ -5,7 +5,7 @@ title: "Accepted our paper to IEEE AIPR2018 Workshop"
 subtitle: ""
 summary: ""
 authors: ["Shunsuke Kitada", "Ryunosuke Kotani", "Hitoshi Iyatomi"]
-tags: ["News"]
+tags: ["News", AIPR, AIPR2018]
 categories: ["News"]
 date: 2018-09-05T00:00:00+09:00
 lastmod: 2022-12-27T23:05:22+09:00

--- a/content/news/acceptance-to-kdd2019/index.md
+++ b/content/news/acceptance-to-kdd2019/index.md
@@ -5,7 +5,7 @@ title: "Accepted our paper to ACM KDD2019 Applied Data Science Track"
 subtitle: ""
 summary: ""
 authors: ["Shunsuke Kitada", "Hitoshi Iyatomi", "Yoshifumi Seki"]
-tags: ["News"]
+tags: ["News", KDD, KDD2019]
 categories: ["News"]
 date: 2019-04-29T00:00:00+09:00
 lastmod: 2022-12-27T22:53:34+09:00

--- a/scripts/sync_conference_news.py
+++ b/scripts/sync_conference_news.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Iterable
 
 from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedSeq
 
 
 CONF_NAME_MAP = {
@@ -70,10 +71,44 @@ class Publication:
     conf: ConferenceKey
 
 
+@dataclass(frozen=True)
+class ConferenceTagKey:
+    """Conference tag identifier used for existing news tag backfill."""
+
+    name: str
+    year: str
+
+
 def slugify_label(value: str) -> str:
     """Convert a human-readable label into a stable slug fragment."""
 
     return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def conference_year_tag(name: str, year: str) -> str:
+    """Return the conference-year tag value such as `CVPR2026`."""
+
+    return f"{name}{year}"
+
+
+def conference_news_tags(name: str, year: str) -> list[str]:
+    """Return the standard news tags for conference news."""
+
+    return ["News", name, conference_year_tag(name, year)]
+
+
+def flow_style_sequence(items: list[str]) -> CommentedSeq:
+    """Return a flow-style YAML sequence for compact front matter lists."""
+
+    sequence = CommentedSeq(items)
+    sequence.fa.set_flow_style()
+    return sequence
+
+
+def conference_news_tags_line(name: str, year: str) -> str:
+    """Return the YAML line for standard conference news tags."""
+
+    return f'tags: ["News", "{name}", "{conference_year_tag(name, year)}"]'
 
 
 class FrontmatterIO:
@@ -145,6 +180,29 @@ def infer_news_kind(tags: object) -> str:
     if normalized_tags & INTERNATIONAL_NEWS_TAGS:
         return NEWS_KIND_ACCEPTANCE
     return NEWS_KIND_PRESENTATIONS
+
+
+def infer_tag_key_from_title(title: str) -> ConferenceTagKey | None:
+    """Infer conference/year tags from a news title when linked publications are insufficient."""
+
+    normalized_title = " ".join(str(title).strip().split())
+    if not normalized_title or "journal" in normalized_title.lower():
+        return None
+
+    matches: list[ConferenceTagKey] = []
+    patterns = (
+        r"([A-Z]+-[A-Z]+)\s*(\d{4})",
+        r"([A-Z]+[A-Z-]*)\s*(\d{4})",
+        r"([A-Z]+)\s+(\d{4})",
+    )
+    for pattern in patterns:
+        for match in re.finditer(pattern, normalized_title):
+            conf = CONF_NAME_MAP.get(match.group(1), match.group(1))
+            matches.append(ConferenceTagKey(conf, match.group(2)))
+
+    if not matches:
+        return None
+    return matches[-1]
 
 
 def parse_conf_key(
@@ -259,6 +317,58 @@ def sync_tags(
     return modified, details
 
 
+def infer_existing_news_tag_key(
+    frontmatter: dict, body: str, publications_by_slug: dict[str, Publication]
+) -> ConferenceTagKey | None:
+    """Infer conference/year tags for an existing acceptance-style news file."""
+
+    linked_slugs = re.findall(r"/publication/([a-zA-Z0-9-]+)", body)
+    linked_keys = {
+        ConferenceTagKey(publication.conf.name, publication.conf.year)
+        for slug in linked_slugs
+        if (publication := publications_by_slug.get(slug)) is not None
+    }
+    if len(linked_keys) == 1:
+        return next(iter(linked_keys))
+
+    return infer_tag_key_from_title(str(frontmatter.get("title") or ""))
+
+
+def sync_existing_news_tags(
+    news_dir: Path,
+    publications_by_slug: dict[str, Publication],
+    io: FrontmatterIO,
+    dry_run: bool,
+) -> tuple[int, list[str]]:
+    """Backfill conference tags for existing acceptance-style conference news."""
+
+    modified = 0
+    details: list[str] = []
+
+    for index_md in sorted(news_dir.glob("acceptance-to-*/index.md")):
+        frontmatter, body = io.read(index_md)
+        tag_key = infer_existing_news_tag_key(frontmatter, body, publications_by_slug)
+        if tag_key is None:
+            continue
+
+        tags = list(frontmatter.get("tags") or [])
+        missing = [
+            tag
+            for tag in conference_news_tags(tag_key.name, tag_key.year)
+            if tag not in tags
+        ]
+        if not missing:
+            continue
+
+        frontmatter["tags"] = flow_style_sequence(tags + missing)
+        modified += 1
+        details.append(f"{index_md.parent.name}: +{', '.join(missing)}")
+        if not dry_run:
+            io.write(index_md, frontmatter, body)
+
+    return modified, details
+
+
 def render_news_markdown(
     conf: ConferenceKey,
     publications: list[Publication],
@@ -270,8 +380,7 @@ def render_news_markdown(
     """Render a complete `content/news/<slug>/index.md` markdown string."""
 
     paper_word = "paper" if len(publications) == 1 else "papers"
-    conf_year_tag = f"{conf.name}{conf.year}"
-    news_tags = f'tags: ["News", "{conf.name}", "{conf_year_tag}"]'
+    news_tags = conference_news_tags_line(conf.name, conf.year)
     if conf.news_kind == NEWS_KIND_ACCEPTANCE:
         title = f"Accepted our {paper_word} to {conf.label}"
         body = (
@@ -455,6 +564,7 @@ def main() -> None:
 
     io = FrontmatterIO()
     publications = parse_publications(publication_dir, io)
+    publications_by_slug = {publication.slug: publication for publication in publications}
     grouped: dict[ConferenceKey, list[Publication]] = defaultdict(list)
     for publication in publications:
         grouped[publication.conf].append(publication)
@@ -477,6 +587,16 @@ def main() -> None:
             print(f"  - {item}")
     else:
         print("[tags] skipped")
+
+    existing_news_modified, existing_news_details = sync_existing_news_tags(
+        news_dir,
+        publications_by_slug,
+        io,
+        args.dry_run,
+    )
+    print(f"[news-tags] modified existing news files: {existing_news_modified}")
+    for item in existing_news_details:
+        print(f"  - {item}")
 
     created = 0
     skipped = 0

--- a/tests/test_sync_conference_news.py
+++ b/tests/test_sync_conference_news.py
@@ -66,3 +66,116 @@ def test_render_news_markdown_keeps_conference_tags_for_acceptance_news() -> Non
     assert 'title: "Accepted our paper to Findings of CVPR 2026"' in markdown
     assert 'tags: ["News", "CVPR", "CVPR2026"]' in markdown
     assert "The following paper has been accepted to Findings of CVPR 2026:" in markdown
+
+
+def test_sync_existing_news_tags_backfills_from_linked_publications(tmp_path: Path) -> None:
+    module = load_sync_conference_news_module()
+
+    news_dir = tmp_path / "content/news"
+    news_file = news_dir / "acceptance-to-eccv2024/index.md"
+    news_file.parent.mkdir(parents=True)
+    news_file.write_text(
+        """---
+title: "Accepted our paper to ECCV2024"
+tags: ["News"]
+categories: ["News"]
+---
+
+- Paper: [Layout-Corrector](/publication/iwai2024layout)
+""",
+        encoding="utf-8",
+    )
+
+    io = module.FrontmatterIO()
+    conf = module.ConferenceKey(
+        name="ECCV",
+        year="2024",
+        display_label="ECCV2024",
+        news_kind=module.NEWS_KIND_ACCEPTANCE,
+    )
+    publications_by_slug = {
+        "iwai2024layout": module.Publication(
+            path=Path("content/publication/iwai2024layout/index.md"),
+            slug="iwai2024layout",
+            title="Layout-Corrector",
+            authors=["Shoma Iwai"],
+            date="2024-07-01T00:00:00+09:00",
+            conf=conf,
+        )
+    }
+
+    modified, details = module.sync_existing_news_tags(
+        news_dir,
+        publications_by_slug,
+        io,
+        dry_run=False,
+    )
+
+    frontmatter, _ = io.read(news_file)
+    assert modified == 1
+    assert details == ["acceptance-to-eccv2024: +ECCV, ECCV2024"]
+    assert list(frontmatter["tags"]) == ["News", "ECCV", "ECCV2024"]
+
+
+def test_sync_existing_news_tags_falls_back_to_title_for_workshop_news(tmp_path: Path) -> None:
+    module = load_sync_conference_news_module()
+
+    news_dir = tmp_path / "content/news"
+    news_file = news_dir / "acceptance-to-iccv2025-found-workshop/index.md"
+    news_file.parent.mkdir(parents=True)
+    news_file.write_text(
+        """---
+title: "Accepted our Workshop Proposal on Foundation Data to ICCV 2025"
+tags: ["News"]
+categories: ["News"]
+---
+
+No publication links yet.
+""",
+        encoding="utf-8",
+    )
+
+    io = module.FrontmatterIO()
+    modified, details = module.sync_existing_news_tags(
+        news_dir,
+        {},
+        io,
+        dry_run=False,
+    )
+
+    frontmatter, _ = io.read(news_file)
+    assert modified == 1
+    assert details == ["acceptance-to-iccv2025-found-workshop: +ICCV, ICCV2025"]
+    assert list(frontmatter["tags"]) == ["News", "ICCV", "ICCV2025"]
+
+
+def test_sync_existing_news_tags_skips_journal_news_without_conference_year(tmp_path: Path) -> None:
+    module = load_sync_conference_news_module()
+
+    news_dir = tmp_path / "content/news"
+    news_file = news_dir / "acceptance-to-ieee-access/index.md"
+    news_file.parent.mkdir(parents=True)
+    news_file.write_text(
+        """---
+title: "Accepted our journal paper to IEEE Access"
+tags: ["News"]
+categories: ["News"]
+---
+
+No conference information.
+""",
+        encoding="utf-8",
+    )
+
+    io = module.FrontmatterIO()
+    modified, details = module.sync_existing_news_tags(
+        news_dir,
+        {},
+        io,
+        dry_run=False,
+    )
+
+    frontmatter, _ = io.read(news_file)
+    assert modified == 0
+    assert details == []
+    assert list(frontmatter["tags"]) == ["News"]


### PR DESCRIPTION
## Summary
- backfill conference and conference-year tags on existing acceptance-style conference news
- cover legacy conference/workshop news such as ACL 2020 SRW, ECCV 2024, KDD 2019, ICLR 2024 workshop, and the ICCV 2025 workshop proposal
- update `scripts/sync_conference_news.py` so existing `acceptance-to-*` news can infer and sync conference tags from linked publications or the news title
- skip journal-style news when no conference-year can be inferred
- add regression tests for linked-publication inference, title fallback, and journal skip behavior
- update the `hugo-conference-news-sync` skill so the documented workflow matches the script behavior

## Testing
- `uv run --with pytest --with ruamel.yaml pytest tests/test_sync_conference_news.py`
- `git diff --check`
- `hugo build`
