### PR TITLE
fix(homepage): prevent biography animation flicker

### DIFF
--- a/layouts/partials/hooks/head-end/animation.html
+++ b/layouts/partials/hooks/head-end/animation.html
@@ -92,6 +92,43 @@
     will-change: transform;
   }
 
+  html.js-about-hero-pending #about #profile {
+    opacity: 0;
+    transform: translateY(26px) scale(0.97);
+  }
+
+  html.js-about-hero-pending #about #profile .avatar {
+    opacity: 0;
+    transform: translateY(22px) scale(0.96);
+  }
+
+  html.js-about-hero-pending #about #profile .portrait-title {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  html.js-about-hero-pending #about h1 {
+    opacity: 0;
+    transform: translateY(20px);
+    letter-spacing: 0.04em;
+  }
+
+  html.js-about-hero-pending #about .article-style,
+  html.js-about-hero-pending #about .ul-interests,
+  html.js-about-hero-pending #about .ul-edu {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+
+  html.js-about-hero-pending #about .col-md-5 .section-subheading,
+  html.js-about-hero-pending #about .col-md-7 .section-subheading,
+  html.js-about-hero-pending #about #profile .network-icon li,
+  html.js-about-hero-pending #about .ul-interests li,
+  html.js-about-hero-pending #about .ul-edu li {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .scroll-progress__bar,
     .js-reveal-item,
@@ -107,8 +144,15 @@
 </style>
 
 <script>
+  (function () {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    if (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    document.documentElement.classList.add('js-about-hero-pending');
+  })();
+
   document.addEventListener('DOMContentLoaded', function () {
     var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    var root = document.documentElement;
 
     initScrollProgress();
     initHeroEntrance();
@@ -154,9 +198,14 @@
 
     function initHeroEntrance() {
       var about = getAboutSection();
-      if (!about) return;
-      if (reducedMotion) return;
-      if (typeof Element === 'undefined' || !Element.prototype.animate) return;
+      if (!about || reducedMotion) {
+        root.classList.remove('js-about-hero-pending');
+        return;
+      }
+      if (typeof Element === 'undefined' || !Element.prototype.animate) {
+        root.classList.remove('js-about-hero-pending');
+        return;
+      }
 
       var profile = about.querySelector('#profile');
       var avatar = about.querySelector('#profile .avatar');
@@ -275,6 +324,8 @@
           fill: 'both'
         });
       });
+
+      root.classList.remove('js-about-hero-pending');
     }
 
     function initScrollReveal(isReduced) {


### PR DESCRIPTION
## Summary
- keep the homepage Biography elements in a pending state before first paint so they do not flash visible and then hide again
- clear that pending state immediately after the existing entrance animations are attached
- skip the pending state for reduced-motion users and browsers without `Element.animate`

## Testing
- build the site with Hugo 0.136.5
