### PR TITLE
Add poster PDF for SciGA publication

### DIFF
--- a/content/publication/kawada2026sciga/index.md
+++ b/content/publication/kawada2026sciga/index.md
@@ -42,7 +42,7 @@ links:
 url_pdf: 
 url_code: https://github.com/IyatomiLab/SciGA
 url_dataset: https://huggingface.co/datasets/iyatomilab/SciGA
-url_poster:
+url_poster: publication/kawada2026sciga/poster.pdf
 url_project: https://iyatomilab.github.io/SciGA/
 url_slides:
 url_source: 


### PR DESCRIPTION
## Why
- publish the poster asset for the SciGA publication page

## What Changed
- add `content/publication/kawada2026sciga/poster.pdf`
- set `url_poster` in `content/publication/kawada2026sciga/index.md` to `publication/kawada2026sciga/poster.pdf`

## Validation
- `make build`
- confirmed generated `public/publication/kawada2026sciga/index.html` links to `/publication/kawada2026sciga/poster.pdf`