### PR TITLE
Enable manual page build deployments

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,6 +1,7 @@
 name: Page Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -72,7 +73,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ${{ vars.ARTIFACT_PATH }}


### PR DESCRIPTION
## Why
- Allow manually triggering the page build and deploy workflow from GitHub Actions when the current `main` branch needs to be redeployed without a new commit.

## What Changed
- Added `workflow_dispatch` to `.github/workflows/gh-pages.yml`.
- Updated the deploy step condition so deployments run for pushes to `main` and manual `workflow_dispatch` runs on `main`.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gh-pages.yml"); puts "yaml ok"'`
- `hugo version`