### PR TITLE
Add ACL SRW acceptance rate to EnsemHalDet publication

### DIFF
--- a/content/publication/miyazato2026ensemhaldet/index.md
+++ b/content/publication/miyazato2026ensemhaldet/index.md
@@ -22,7 +22,7 @@ publication_short: "ACL2026 SRW"
 abstract: "Vision-Language Models (VLMs) excel at multimodal tasks, but they remain vulnerable to hallucinations that are factually incorrect or ungrounded in the input image. Recent work suggests that hallucination detection using internal representations is more efficient and accurate than approaches that rely solely on model outputs. However, existing internal-representation-based methods typically rely on a single representation or detector, limiting their ability to capture diverse hallucination signals. In this paper, we propose EnsemHalDet, an ensemble-based hallucination detection framework that leverages multiple internal representations of VLMs, including attention outputs and hidden states. EnsemHalDet trains independent detectors for each representation and combines them through ensemble learning. Experimental results across multiple VQA datasets and VLMs show that EnsemHalDet consistently outperforms prior methods and single-detector models in terms of AUC. These results demonstrate that ensembling diverse internal signals significantly improves robustness in multimodal hallucination detection."
 
 # Summary. An optional shortened abstract.
-summary: "Proc. ACL SRW 2026"
+summary: "Proc. ACL SRW 2026 (**Acceptance rate = 32.41%**; non-archival publication)"
 
 tags:
 - "International Publication"


### PR DESCRIPTION
## Why
- Add the ACL SRW 2026 acceptance rate to the EnsemHalDet publication entry.
- Keep the note in the summary field and clarify that ACL SRW is a non-archival publication.

## What Changed
- Updated `content/publication/miyazato2026ensemhaldet/index.md`.
- Added `Acceptance rate = 32.41%` and `non-archival publication` to the summary text.

## Validation
- Reviewed the diff for `content/publication/miyazato2026ensemhaldet/index.md` only.
- No automated tests were run for this content-only metadata update.