### PR TITLE
Add ACL SRW acceptance rate to A11y-Compressor publication

### DIFF
--- a/content/publication/takeshita2026a11ycompressor/index.md
+++ b/content/publication/takeshita2026a11ycompressor/index.md
@@ -22,7 +22,7 @@ publication_short: "ACL2026 SRW"
 abstract: "AI agents that interact with graphical user interfaces (GUIs) require effective observation representations for reliable grounding. The accessibility tree is a commonly used text-based format that encodes UI element attributes, but it suffers from redundancy and lacks structural information such as spatial relationships among elements. We propose A11y-Compressor, a framework that transforms linearized accessibility trees into compact and structured representations. Our implementation, Compressed-a11y, applies a lightweight and structured transformation pipeline with modal detection, redundancy reduction, and semantic structuring. Experiments on the OSWorld benchmark show that Compressed-a11y reduces input tokens to 22% of the original while improving task success rates by 5.1 percentage points on average."
 
 # Summary. An optional shortened abstract.
-summary: "Proc. ACL SRW 2026"
+summary: "Proc. ACL SRW 2026 (**Acceptance rate = 32.41%**)"
 
 tags:
 - "International Publication"


### PR DESCRIPTION
## Why
- Add the ACL SRW 2026 acceptance rate to the A11y-Compressor publication entry.

## What Changed
- Updated `content/publication/takeshita2026a11ycompressor/index.md`.
- Added `Acceptance rate = 32.41%` to the summary text.

## Validation
- Reviewed the diff for `content/publication/takeshita2026a11ycompressor/index.md` only.
- No automated tests were run for this content-only metadata update.