### PR TITLE
feat(publication): add poster and CVF links for CVPR findings pages

### DIFF
--- a/.lychee/exclude-temporary.txt
+++ b/.lychee/exclude-temporary.txt
@@ -21,3 +21,4 @@ hatenablog-parts.com/embed
 bit.ly/KitadaXColosoJP1
 confit.atlas.jp
 www.scimagojr.com
+clustrmaps.com

--- a/content/publication/kawada2026sciga/index.md
+++ b/content/publication/kawada2026sciga/index.md
@@ -38,6 +38,8 @@ links:
   url: https://arxiv.org/abs/2507.02212
   icon_pack: ai
   icon: arxiv
+- name: CVF
+  url: https://openaccess.thecvf.com/content/CVPR2026F/html/Kawada_SciGA_A_Comprehensive_Dataset_for_Designing_Graphical_Abstracts_in_Academic_CVPRF_2026_paper.html
 
 url_pdf: 
 url_code: https://github.com/IyatomiLab/SciGA

--- a/content/publication/nagai2026taue/index.md
+++ b/content/publication/nagai2026taue/index.md
@@ -49,7 +49,7 @@ links:
 url_pdf:
 url_code:
 url_dataset:
-url_poster:
+url_poster: publication/nagai2026taue/poster.pdf
 url_project: https://iyatomilab.github.io/TAUE
 url_slides:
 url_source:

--- a/content/publication/nagai2026taue/index.md
+++ b/content/publication/nagai2026taue/index.md
@@ -45,6 +45,8 @@ links:
   url: https://arxiv.org/abs/2511.02580
   icon_pack: ai
   icon: arxiv
+- name: CVF
+  url: https://openaccess.thecvf.com/content/CVPR2026F/html/Nagai_TAUE_Training-free_Noise_Transplant_and_Cultivation_Diffusion_Model_CVPRF_2026_paper.html
 
 url_pdf:
 url_code:


### PR DESCRIPTION
## Why

Expose the official CVF pages for the two CVPR 2026 Findings publications, keep the TAUE publication page linked to its poster asset, and stabilize the PR link check against the known flaky `clustrmaps.com` endpoint.

## What Changed

- Added `content/publication/nagai2026taue/poster.pdf` and set `url_poster: publication/nagai2026taue/poster.pdf` in `content/publication/nagai2026taue/index.md`.
- Added a `CVF` link after the existing `Preprint` link in `content/publication/kawada2026sciga/index.md`.
- Added a `CVF` link after the existing `Preprint` link in `content/publication/nagai2026taue/index.md`.
- Added `clustrmaps.com` to `.lychee/exclude-temporary.txt` so the PR link check does not fail on that unrelated external network issue.

## Validation

Check that both publication front matters still parse and expose `Preprint, CVF` in order.
```shell
ruby -e 'require "yaml"; require "date"; ["content/publication/kawada2026sciga/index.md", "content/publication/nagai2026taue/index.md"].each do |path|; text = File.read(path); yaml = text.split(/^---\\s*$\\n/)[1]; data = YAML.safe_load(yaml, permitted_classes: [Date, Time], aliases: true); puts "#{path}: #{data.fetch("links").map { |h| h["name"] }.join(", ")}"; end'
```

Inspect the temporary Lychee exclusions and confirm `clustrmaps.com` is listed.
```shell
rg -n '^clustrmaps\.com$' .lychee/exclude-temporary.txt
```

Attempt a full Hugo build from the task worktree. This currently fails because of the pre-existing missing `about.biography` block in `layouts/partials/blocks/about.biography.html`, not because of these publication edits.
```shell
MISE_DISABLE=1 make build
```
