### PR TITLE
ci: gate deploy on link check, add pytest workflow, and harden permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -60,6 +60,13 @@ jobs:
       # Checkout the repository to access the lychee config file
       - uses: actions/checkout@v7
 
+      # Keep mise.toml as the single source of truth for the lychee version
+      - name: Read lychee version from mise.toml
+        id: lychee-version
+        run: |
+          version="$(python3 -c 'import tomllib; print(tomllib.load(open("mise.toml", "rb"))["tools"]["lychee"])')"
+          echo "version=v${version}" >> "$GITHUB_OUTPUT"
+
       - name: Download Build Artifact
         uses: actions/download-artifact@v8
         with:
@@ -71,7 +78,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: true
-          lycheeVersion: v0.24.2
+          lycheeVersion: ${{ steps.lychee-version.outputs.version }}
           # --root-dir is required to resolve root-relative links (e.g. /talk/...)
           # in the built HTML; without it lychee silently skips them.
           args: "${{ vars.ARTIFACT_PATH }} --root-dir ${{ github.workspace }}/${{ vars.ARTIFACT_PATH }} --config .lychee/config.toml --exclude-file .lychee/exclude-temporary.txt --exclude-file .lychee/exclude-permanent.txt"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-typo:
     runs-on: ubuntu-latest
@@ -68,13 +71,14 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: true
-          lycheeVersion: v0.21.0
+          lycheeVersion: v0.24.2
           # --root-dir is required to resolve root-relative links (e.g. /talk/...)
           # in the built HTML; without it lychee silently skips them.
           args: "${{ vars.ARTIFACT_PATH }} --root-dir ${{ github.workspace }}/${{ vars.ARTIFACT_PATH }} --config .lychee/config.toml --exclude-file .lychee/exclude-temporary.txt --exclude-file .lychee/exclude-permanent.txt"
 
   deploy:
-    needs: build
+    needs: [build, check-broken-links]
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
@@ -86,7 +90,6 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
-        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ${{ vars.ARTIFACT_PATH }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -79,8 +79,9 @@ jobs:
         with:
           fail: true
           lycheeVersion: ${{ steps.lychee-version.outputs.version }}
-          # --root-dir is required to resolve root-relative links (e.g. /talk/...)
-          # in the built HTML; without it lychee silently skips them.
+          # --root-dir is required since lychee v0.24 to resolve root-relative
+          # links (e.g. /talk/...) in the built HTML; without it lychee errors
+          # out instead of silently skipping them like v0.21 did.
           args: "${{ vars.ARTIFACT_PATH }} --root-dir ${{ github.workspace }}/${{ vars.ARTIFACT_PATH }} --config .lychee/config.toml --exclude-file .lychee/exclude-temporary.txt --exclude-file .lychee/exclude-permanent.txt"
 
   deploy:

--- a/.github/workflows/lychee-prune.yml
+++ b/.github/workflows/lychee-prune.yml
@@ -43,6 +43,14 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      # Keep mise.toml as the single source of truth for the lychee version.
+      # Read it here, before "Prepare prune branch" switches branches.
+      - name: Read lychee version from mise.toml
+        id: lychee-version
+        run: |
+          version="$(python3 -c 'import tomllib; print(tomllib.load(open("mise.toml", "rb"))["tools"]["lychee"])')"
+          echo "version=v${version}" >> "$GITHUB_OUTPUT"
+
       - name: Download Build Artifact
         uses: actions/download-artifact@v8
         with:
@@ -89,7 +97,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
-          lycheeVersion: v0.24.2
+          lycheeVersion: ${{ steps.lychee-version.outputs.version }}
           format: json
           output: lychee-excludes.json
           args: "--config .lychee/config.toml lychee-input.txt"

--- a/.github/workflows/lychee-prune.yml
+++ b/.github/workflows/lychee-prune.yml
@@ -89,7 +89,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
-          lycheeVersion: v0.21.0
+          lycheeVersion: v0.24.2
           format: json
           output: lychee-excludes.json
           args: "--config .lychee/config.toml lychee-input.txt"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,33 @@
+name: Pytest
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "tests/**"
+      - "scripts/**"
+      - ".agents/skills/**"
+      - ".github/workflows/pytest.yml"
+  pull_request:
+    paths:
+      - "tests/**"
+      - "scripts/**"
+      - ".agents/skills/**"
+      - ".github/workflows/pytest.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.3.2
+
+      - name: Run tests
+        run: uv run --with pytest --with ruamel.yaml pytest tests/ -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Pytest
+name: Test
 
 on:
   push:
@@ -8,19 +8,19 @@ on:
       - "tests/**"
       - "scripts/**"
       - ".agents/skills/**"
-      - ".github/workflows/pytest.yml"
+      - ".github/workflows/test.yml"
   pull_request:
     paths:
       - "tests/**"
       - "scripts/**"
       - ".agents/skills/**"
-      - ".github/workflows/pytest.yml"
+      - ".github/workflows/test.yml"
 
 permissions:
   contents: read
 
 jobs:
-  pytest:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.lychee/exclude-temporary.txt
+++ b/.lychee/exclude-temporary.txt
@@ -23,3 +23,8 @@ confit.atlas.jp
 www.scimagojr.com
 clustrmaps.com
 www.meethawaii.com/convention-center/
+
+# The page is alive (curl returns 200) but lychee >= v0.24 (rustls) cannot
+# complete a TLS handshake because the server only offers legacy TLS cipher
+# suites. Re-check regularly in case the server's TLS config is upgraded.
+book.impress.co.jp

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -40,7 +40,7 @@ imaging:
   resampleFilter: Lanczos
   quality: 75
   anchor: Smart
-timeout: 600000
+timeout: "600s"
 taxonomies:
   tag: tags
   category: categories

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
 hugo-extended = "0.136.5"
-lychee = "latest"
+lychee = "0.24.2"
 
 "go:github.com/shunk031/tcardgen" = "latest"


### PR DESCRIPTION
## Summary

- **Gate deploy on link check**: `deploy` now `needs: [build, check-broken-links]` in `gh-pages.yml`, so a broken-link failure blocks the gh-pages publish instead of racing it (previously `check-broken-links` and `deploy` both only depended on `build` and ran in parallel with no ordering guarantee).
- **Harden permissions**: added top-level `permissions: contents: read` to `gh-pages.yml`. Deploy uses the `ACTIONS_DEPLOY_KEY` deploy_key secret, not `GITHUB_TOKEN`, so no write scope is required.
- **Job-level skip for PRs**: moved the `(github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'` condition from the `Deploy` step's `if:` up to the `deploy` job's `if:`. Previously PR runs still executed the whole `deploy` job (downloading the artifact) only to skip the final step as a no-op; now the entire job is skipped on PRs.
- **Bump lychee and single-source its version**: `v0.21.0` → `v0.24.2` (latest stable, per `gh api repos/lycheeverse/lychee/releases/latest`). The version is pinned once in `mise.toml` (`lychee = "0.24.2"`, was `"latest"`), and both `gh-pages.yml` and `lychee-prune.yml` read it from `mise.toml` at runtime (`tomllib` one-liner → step output → `lycheeVersion:`) instead of hardcoding it per workflow, so there is no duplicate version management. In `lychee-prune.yml` the version is read right after checkout, before the prune-branch step switches branches.
- **Add test workflow**: new `.github/workflows/test.yml` (workflow name `Test`, job `test`) runs `tests/` via `uv run --with pytest --with ruamel.yaml pytest tests/ -q` using `astral-sh/setup-uv@v8.3.2` (latest release), triggered on `pull_request` and `push` to `main`, scoped with `paths:` to `tests/**`, `scripts/**`, `.agents/skills/**`, and the workflow file itself (`.github/workflows/test.yml`) so changes to the workflow are also CI-verified before merge. `permissions: contents: read` only.
- **Fix Hugo timeout**: `config/_default/hugo.yaml`'s bare `timeout: 600000` changed to `timeout: "600s"`. This is a behavioral change, not just a notation cleanup: Hugo v0.136.5 interprets the bare number `600000` as **seconds**, so the effective timeout was ~166 hours. The original `600000` appears to be a leftover from Hugo's old milliseconds interpretation (600000 ms = 10 min), so `"600s"` restores the originally intended 10-minute timeout unambiguously.

## Test plan

- [x] Parsed all changed/added YAML (`gh-pages.yml`, `lychee-prune.yml`, `test.yml`, `hugo.yaml`) and `mise.toml` with `yaml.safe_load` / `tomllib.load` — all valid.
- [x] Verified the mise.toml version-extraction one-liner locally: prints `v0.24.2`.
- [x] `uv run --with pytest --with ruamel.yaml pytest tests/ -q` → 18 passed.
- [x] `mise exec -- hugo --gc --minify` → builds successfully (821 pages) with the new `timeout: "600s"`.
- [x] `actionlint` run over all workflow files (via `mise exec actionlint@latest`) → no findings, exit code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)