### PR TITLE
feat(ci): add frontmatter lint script and workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Frontmatter Lint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "content/**"
+      - "scripts/lint_frontmatter.py"
+      - ".github/workflows/lint.yml"
+  pull_request:
+    paths:
+      - "content/**"
+      - "scripts/lint_frontmatter.py"
+      - ".github/workflows/lint.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint-frontmatter:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.3.2
+
+      - name: Lint frontmatter
+        run: uv run --with ruamel.yaml python scripts/lint_frontmatter.py

--- a/scripts/lint_frontmatter.py
+++ b/scripts/lint_frontmatter.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Lint Hugo content frontmatter for issues typo checkers cannot catch.
+
+Checks:
+  (a) Frontmatter keys containing non-ASCII characters. These are valid YAML
+      (e.g. a full-width "１" glued onto "projects") but Hugo silently
+      ignores the resulting key instead of erroring, so the config the key
+      was meant to set never takes effect.
+  (b) tags/categories values that share a casefolded spelling but differ in
+      case (e.g. "Non-refereed" vs "Non-Refereed"). Both are valid English,
+      so a spell checker won't flag them, but Hugo treats each spelling as a
+      distinct taxonomy term and generates a separate (wrong) term page.
+
+Usage:
+    python scripts/lint_frontmatter.py [--content-dir content]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+from collections import defaultdict
+from io import StringIO
+from typing import Any, Iterable
+
+from ruamel.yaml import YAML
+
+FRONTMATTER_LIST_FIELDS = ("tags", "categories")
+
+# Pre-existing tag/category casing variants that predate this lint. They are
+# reported as warnings (not build failures) until a dedicated content-cleanup
+# PR normalizes them. Remove entries here as they get fixed upstream.
+KNOWN_CASING_EXCEPTIONS: set[tuple[str, str]] = {
+    ("tags", "invited talk"),
+    ("categories", "multi-modal model"),
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Lint Hugo content frontmatter for non-ASCII keys and tag/category casing drift."
+    )
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    parser.add_argument(
+        "--content-dir",
+        type=pathlib.Path,
+        default=repo_root / "content",
+        help="Path to content directory (default: content/)",
+    )
+    return parser.parse_args()
+
+
+def iter_markdown_files(content_dir: pathlib.Path) -> Iterable[pathlib.Path]:
+    yield from sorted(content_dir.rglob("*.md"))
+
+
+def load_frontmatter(path: pathlib.Path) -> dict[str, Any] | None:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return None
+    yaml = YAML(typ="safe")
+    data = yaml.load(StringIO(parts[1]))
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def find_non_ascii_keys(frontmatter: dict[str, Any]) -> list[str]:
+    return [key for key in frontmatter if isinstance(key, str) and not key.isascii()]
+
+
+def collect_casing_groups(
+    content_dir: pathlib.Path,
+) -> dict[tuple[str, str], dict[str, set[pathlib.Path]]]:
+    """Map (field, casefolded value) -> {spelling: {file paths using it}}."""
+    groups: dict[tuple[str, str], dict[str, set[pathlib.Path]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+    for path in iter_markdown_files(content_dir):
+        frontmatter = load_frontmatter(path)
+        if frontmatter is None:
+            continue
+        for field in FRONTMATTER_LIST_FIELDS:
+            values = frontmatter.get(field)
+            if not isinstance(values, list):
+                continue
+            for value in values:
+                if not isinstance(value, str):
+                    continue
+                groups[(field, value.casefold())][value].add(path)
+    return groups
+
+
+def main() -> int:
+    args = parse_args()
+
+    violations: list[str] = []
+    warnings: list[str] = []
+    checked = 0
+
+    for path in iter_markdown_files(args.content_dir):
+        frontmatter = load_frontmatter(path)
+        if frontmatter is None:
+            continue
+        checked += 1
+        for key in find_non_ascii_keys(frontmatter):
+            violations.append(
+                f"{path}: frontmatter key {key!r} contains non-ASCII characters"
+            )
+
+    groups = collect_casing_groups(args.content_dir)
+    for (field, casefold_key), spellings in groups.items():
+        if len(spellings) <= 1:
+            continue
+        other_spellings = sorted(spellings)
+        for spelling, paths in sorted(spellings.items()):
+            conflicts = [s for s in other_spellings if s != spelling]
+            for path in sorted(paths):
+                line = (
+                    f"{path}: {field} value {spelling!r} has inconsistent casing "
+                    f"with {conflicts!r} (casefold key: {casefold_key!r})"
+                )
+                if (field, casefold_key) in KNOWN_CASING_EXCEPTIONS:
+                    warnings.append(line)
+                else:
+                    violations.append(line)
+
+    if warnings:
+        print("Known pre-existing casing issues (reported, not failing the build):")
+        for warning in sorted(warnings):
+            print(warning)
+        print()
+
+    if violations:
+        print("Frontmatter lint violations:")
+        for violation in sorted(violations):
+            print(violation)
+        return 1
+
+    print(f"frontmatter lint OK ({checked} files checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_lint_frontmatter.py
+++ b/tests/test_lint_frontmatter.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "lint_frontmatter.py"
+
+
+def run_lint(content_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--content-dir", str(content_dir)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_post(path: Path, frontmatter: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\n{frontmatter}\n---\nbody\n", encoding="utf-8")
+
+
+def test_passes_on_clean_content(tmp_path: Path) -> None:
+    write_post(
+        tmp_path / "post" / "a" / "index.md",
+        'title: "A"\ntags: ["Foo", "Bar"]\ncategories: ["Baz"]\n',
+    )
+    write_post(
+        tmp_path / "post" / "b" / "index.md",
+        'title: "B"\ntags: ["Bar"]\ncategories: ["Baz"]\n',
+    )
+
+    result = run_lint(tmp_path)
+
+    assert result.returncode == 0, result.stdout
+    assert "frontmatter lint OK" in result.stdout
+
+
+def test_detects_non_ascii_frontmatter_key(tmp_path: Path) -> None:
+    write_post(
+        tmp_path / "post" / "a" / "index.md",
+        'title: "A"\n１projects: []\n',
+    )
+
+    result = run_lint(tmp_path)
+
+    assert result.returncode == 1
+    assert "non-ASCII characters" in result.stdout
+    assert "１projects" in result.stdout
+
+
+def test_detects_tag_casing_mismatch(tmp_path: Path) -> None:
+    write_post(
+        tmp_path / "post" / "a" / "index.md",
+        'title: "A"\ntags: ["Foo Bar"]\n',
+    )
+    write_post(
+        tmp_path / "post" / "b" / "index.md",
+        'title: "B"\ntags: ["foo bar"]\n',
+    )
+
+    result = run_lint(tmp_path)
+
+    assert result.returncode == 1
+    assert "inconsistent casing" in result.stdout
+    assert "'Foo Bar'" in result.stdout
+    assert "'foo bar'" in result.stdout
+
+
+def test_known_casing_exception_is_reported_as_warning_not_failure(
+    tmp_path: Path,
+) -> None:
+    write_post(
+        tmp_path / "post" / "a" / "index.md",
+        'title: "A"\ntags: ["Invited talk"]\n',
+    )
+    write_post(
+        tmp_path / "post" / "b" / "index.md",
+        'title: "B"\ntags: ["Invited Talk"]\n',
+    )
+
+    result = run_lint(tmp_path)
+
+    assert result.returncode == 0, result.stdout
+    assert "Known pre-existing casing issues" in result.stdout
+    assert "Invited talk" in result.stdout


### PR DESCRIPTION
Closes #378

## 概要

typos (スペルチェッカー) では原理的に検知できない frontmatter の問題を CI で検査する lint を追加します。PR #375 のレビューで見つかった以下の 2 種類の問題が動機です。

- 全角文字が混入したキー (`１projects: []`): YAML として合法なため Hugo は黙って無視し、設定が効かないまま気づけない
- タグの大文字小文字ゆれ (`Non-Refereed` vs `Non-refereed`): どちらも正しい英単語のためスペルチェック対象外だが、Hugo は別々のタクソノミーページを生成してしまう

## 変更内容

- `scripts/lint_frontmatter.py`: `content/**/*.md` の frontmatter を ruamel.yaml でパースし、以下を検査
  - (a) 非 ASCII 文字を含むトップレベルキー名の検出 → violation (exit 1)
  - (b) tags / categories を casefold でグルーピングし、同一グループ内に複数の表記がある場合に全出現箇所を `ファイルパス: 指摘内容` 形式で表示 → violation (exit 1)
  - `--content-dir` 引数対応 (デフォルト `content/`)
- `tests/test_lint_frontmatter.py`: 正常系 exit 0 / 非 ASCII キー検知 / 表記ゆれ検知 / 既知例外の warning 扱い、の 4 テスト
- `.github/workflows/lint.yml`: `push` (main) と `pull_request` で実行。paths フィルタは `content/**`, `scripts/lint_frontmatter.py`, ワークフロー自身。`permissions: contents: read`

## 既知の表記ゆれ (warning 扱い)

現行コンテンツに残っている以下 2 グループは、`KNOWN_CASING_EXCEPTIONS` allowlist で warning として報告のみ行い、CI は落としません (別 PR での正規化を想定。正規化後に allowlist から削除してください)。

- tags: `Invited talk` / `Invited Talk` (event 配下 9 ファイル)
- categories: `Multi-modal model` / `Multi-modal Model` (publication 配下 3 ファイル)

## 検証

- `uv run --with pytest --with ruamel.yaml pytest tests/ -q` → 31 passed (既存 27 + 新規 4)
- `uv run --with ruamel.yaml python scripts/lint_frontmatter.py` → 現行 content 190 ファイルで exit 0 (上記 warning のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)