### PR TITLE
fix(config): remove defunct Universal Analytics ID

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -22,7 +22,12 @@ marketing:
     description: ""
     twitter: "shunk031"
   analytics:
-    google_analytics: "UA-114287158-2"
+    # Universal Analytics (UA-*) stopped collecting data in July 2023.
+    # The theme (blox-seo) renders this ID via gtag.js, so it already
+    # supports GA4 measurement IDs (G-XXXXXXXXXX) as-is.
+    # Set a GA4 measurement ID here once one has been issued in the
+    # Google Analytics admin console (Admin > Data Streams).
+    google_analytics: ""
     baidu_tongji: ""
     google_tag_manager: ""
     microsoft_clarity: ""


### PR DESCRIPTION
## Summary

- `marketing.analytics.google_analytics` was set to `UA-114287158-2`, a Universal Analytics property ID. UA stopped collecting data in July 2023, so this script has been dead weight (fires a request, does nothing useful) on every page load since then.
- Cleared the dead UA ID to `""` and added a comment in `config/_default/params.yaml` documenting how to enable GA4.

## Investigation

Checked the theme's rendering of `marketing.analytics.google_analytics` in the Hugo Module cache for `blox-seo@v0.2.3` (`layouts/partials/analytics/google_analytics.html`, wired up via `layouts/partials/analytics/main.html`):

```go-html-template
{{ $ga := site.Params.marketing.analytics.google_analytics | default "" }}
{{ if hugo.IsProduction | and $ga }}
<script async src="https://www.googletagmanager.com/gtag/js?id={{$ga}}"></script>
<script>
  ...
  gtag('config', '{{$ga}}', {{$gtag_config|safeJS}});
  ...
</script>
{{ end }}
```

The theme loads `gtag.js` and forwards whatever ID is configured straight into `gtag('config', ...)` — it does not special-case the `UA-`/`G-` prefix. This means **the theme already supports GA4 measurement IDs (`G-XXXXXXXXXX`) with no template changes required**; only the value in `params.yaml` needs to change.

Built the site with `mise exec -- hugo --gc --minify` before and after the change:
- Before: `public/index.html` contained `<script async src="https://www.googletagmanager.com/gtag/js?id=UA-114287158-2">` and a `gtag('config', 'UA-114287158-2', {})` call — a dead request/config since UA sunset.
- After: no `gtag`/`googletagmanager`/`UA-114287158` references appear anywhere in the generated output.

## How to enable GA4

1. In the Google Analytics admin console, create a GA4 property (if not already done) and add a Web data stream for `shunk031.me`.
2. Copy the **Measurement ID** (`G-XXXXXXXXXX`) from Admin > Data Streams > (the web stream).
3. Set `marketing.analytics.google_analytics: "G-XXXXXXXXXX"` in `config/_default/params.yaml`.

No other code changes are needed — the theme will pick it up automatically.

## Test plan

- [x] `mise exec -- hugo --gc --minify` builds successfully
- [x] Generated `public/index.html` no longer contains the UA ID or a `gtag`/`googletagmanager` script tag
- [x] Confirmed via theme source that `google_analytics` is rendered through `gtag.js`, so a future GA4 ID will work without further template changes

Refs #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)