### PR TITLE
chore(deps): upgrade Hugo 0.136.5 -> 0.155.3 (staged, hugo-blox-builder lineage)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HUGO_VERSION := 0.136.5
+HUGO_VERSION := 0.155.3
 # HUGO_CMD := container run --rm -v $(PWD):/project -v $(HOME)/Library/Caches/hugo_cache:/cache -p 1313:1313 ghcr.io/gohugoio/hugo:v$(HUGO_VERSION)
 HUGO_CMD := hugo
 PRUNE_DRY_RUN ?= 1

--- a/content/event/_index.md
+++ b/content/event/_index.md
@@ -3,10 +3,16 @@ title: Recent & Upcoming Talks
 cms_exclude: true
 
 # View.
-#   1 = List
-#   2 = Compact
-#   3 = Card
-view: 2
+#   list = List
+#   compact = Compact
+#   card = Card
+#
+# NOTE: Hugo >=0.153 decodes unsigned front matter integers as uint64 (not
+# int/int64), so the theme's legacy numeric `view` mapping in
+# partials/functions/render_view.html (blox-bootstrap v5.9.7) no longer
+# matches and silently falls back to "compact". Using the string form here
+# avoids relying on that legacy numeric branch entirely.
+view: compact
 
 # Optional header image (relative to `static/media/` folder).
 header:

--- a/content/post/_index.md
+++ b/content/post/_index.md
@@ -3,10 +3,16 @@ title: Posts
 cms_exclude: true
 
 # View.
-#   1 = List
-#   2 = Compact
-#   3 = Card
-view: 2
+#   list = List
+#   compact = Compact
+#   card = Card
+#
+# NOTE: Hugo >=0.153 decodes unsigned front matter integers as uint64 (not
+# int/int64), so the theme's legacy numeric `view` mapping in
+# partials/functions/render_view.html (blox-bootstrap v5.9.7) no longer
+# matches and silently falls back to "compact". Using the string form here
+# avoids relying on that legacy numeric branch entirely.
+view: compact
 
 # Optional header image (relative to `static/media/` folder).
 header:

--- a/content/publication/_index.md
+++ b/content/publication/_index.md
@@ -3,11 +3,17 @@ title: Publications
 cms_exclude: true
 
 # View.
-#   1 = List
-#   2 = Compact
-#   3 = Card
-#   4 = Citation
-view: 4
+#   list = List
+#   compact = Compact
+#   card = Card
+#   citation = Citation
+#
+# NOTE: Hugo >=0.153 decodes unsigned front matter integers as uint64 (not
+# int/int64), so the theme's legacy numeric `view` mapping in
+# partials/functions/render_view.html (blox-bootstrap v5.9.7) no longer
+# matches and silently falls back to "compact". Using the string form here
+# avoids relying on that legacy numeric branch entirely.
+view: citation
 
 # Optional header image (relative to `static/media/` folder).
 header:

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-hugo-extended = "0.136.5"
+hugo-extended = "0.155.3"
 lychee = "0.24.2"
 
 "go:github.com/shunk031/tcardgen" = "latest"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["mise"]
+}


### PR DESCRIPTION
## Summary

Staged Hugo upgrade attempt per #380: bump Hugo as far as possible within the currently pinned `hugo-blox-builder` v5.9.7 lineage (kit migration is explicitly out of scope / future work), fixing what's fixable locally and stopping at the highest version that still builds cleanly.

- **Hugo**: `0.136.5` → `0.155.3` (`mise.toml`, `Makefile`). `go.mod` is untouched — still pinned to the same `hugo-blox-builder` module versions (`blox-bootstrap/v5@v5.9.7`, `blox-core@v0.3.1`, `blox-plugin-netlify@v1.1.1`, `blox-plugin-reveal@v1.1.2`, `blox-seo@v0.2.3`).
- **Content fix**: `content/{post,event,publication}/_index.md` — `view:` front matter changed from legacy numeric codes (`2`, `2`, `4`) to string form (`compact`, `compact`, `citation`).
- **New**: minimal `renovate.json` enabling only Renovate's `mise` manager, so `hugo-extended`/`lychee` bumps in `mise.toml` get proposed automatically going forward (Dependabot keeps owning `github-actions`/`gomod` as before — no overlap).

## Why 0.155.3 and not the latest (0.164.0)

Hugo **v0.156.0** fully removed the legacy `getCSV` global template function (deprecated since v0.123.0, "logged as error" since v0.136.0, removed in v0.156.0). `blox-bootstrap/v5@v5.9.7`'s `layouts/shortcodes/table.html` still calls `getCSV`, so Hugo fails to even *parse* that template at startup, regardless of whether the `table` shortcode is used in content:

```
ERROR error building site: ".../blox-bootstrap/v5@v5.9.7/layouts/shortcodes/table.html:29:1":
parse of template failed: template: _shortcodes/table.html:29: function "getCSV" not defined
```

`blox-bootstrap/v5@v5.9.7` is the **latest published version** of that module (confirmed via the Go module proxy and GitHub tags — no newer release exists), so this cannot be fixed by bumping module versions while staying in the `hugo-blox-builder` lineage. This failure is identical at every version from 0.156.0 through the latest 0.164.0, so **0.155.3** (highest available 0.155.x patch) is the practical ceiling for this round.

## What else broke, and what was fixed

Along the way (starting around Hugo v0.153), Hugo's YAML front-matter decoder began returning unsigned integers as Go `uint64` instead of `int`/`int64`. `blox-bootstrap`'s `partials/functions/render_view.html` only special-cases `int`/`int64` when mapping the theme's legacy numeric `view: 1-5` front matter to a view name; a `uint64` falls through to the string branch, the lookup fails, and it silently falls back to the "compact" view. This was a **real content regression**: the Publications list page (`view: 4` = Citation) started rendering with the wrong "compact" card layout instead of the intended citation-style layout, and Hugo logged:

```
WARN  Failed to locate view at `partials/views/%!s(uint64=4).html`. Check you specified a supported `view` in `publication/_index.md`
```

Fixed by switching the three affected `_index.md` front-matter files from numeric `view:` codes to the equivalent string form (`compact`, `citation`), which bypasses the buggy numeric-type branch entirely — no theme/module code was touched.

**No `layouts/` template changes were needed** in this round. The two known-risk override files (`layouts/partials/blocks/about.biography.html` and `layouts/partials/blocks/v1/about.html`) build and render identically to the 0.136.5 baseline at 0.155.3 — the upstream `about.biography.html`/`v1/about.html` structure hasn't changed between these versions.

## Verification

- `hugo --gc --minify --printUnusedTemplates`: exit 0. Page count **819**, Aliases **251** — matches the 0.136.5 baseline exactly.
- CI's exact command (`hugo --printUnusedTemplates`, per `.github/workflows/gh-pages.yml`): exit 0, and the "unused local template" grep check (`is unused, source file $GITHUB_WORKSPACE/layouts/`) finds nothing — only theme-module-side entries remain in the unused-template list.
- No deprecated-config-key warnings at 0.155.3 (the `languages.en.languageCode` deprecation only starts appearing at Hugo v0.158.0, so it's not yet relevant here — noted for the next round of this staged upgrade).
- `hugo mod graph`: no dangling/broken module references.
- Diffed the four key generated pages (`public/index.html`, `public/authors/shunsuke-kitada/index.html`, `public/event/index.html`, `public/publication/index.html`) against the 0.136.5 baseline: byte-identical after normalizing asset-fingerprint hashes and the "Last Published" date — no structural/content differences remain after the `view:` fix.

## Follow-up (not in this PR)

- Migrating to `HugoBlox/kit` remains separate future work (per #380) and would be required to move past Hugo v0.155.x, since it's the only path to a `table.html` shortcode that doesn't call `getCSV`.
- The `languages.en.languageCode` → `languages.en.locale` rename (deprecated starting Hugo v0.158.0) will need to be applied in a future round once/if Hugo is bumped past that line.

Refs #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)