### PR TITLE
refactor: simplify Projects filters

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -236,14 +236,8 @@ sections:
           filter: '.js-id-posters:not(.js-id-domestic-conference)'
         - name: 'Posters 🇯🇵'
           filter: '.js-id-posters.js-id-domestic-conference'
-        - name: 'Official Implementation'
+        - name: 'Official Implementation 💻'
           tag:  'Official Implementation'
-        - name: 'PyTorch'
-          tag:  'PyTorch'
-        - name: 'Chainer'
-          tag:  'Chainer'
-        - name: 'Tool'
-          tag:  'Tool'
     design:
       # Choose how many columns the section has. Valid values: '1' or '2'.
       columns: '1'

--- a/content/publication/aoki2020text/index.md
+++ b/content/publication/aoki2020text/index.md
@@ -26,7 +26,7 @@ We propose a new character-based text classification framework for non-alphabeti
 # Summary. An optional shortened abstract.
 summary: "Proc. AACL-IJCNLP SRW 2020"
 
-tags: ["International Conference", "Refereed", "Natural Language Processing", "International Publication", "AACL-IJCNLP", "AACL-IJCNLP2020"]
+tags: ["International Conference", "Refereed", "Natural Language Processing", "International Publication", "AACL-IJCNLP", "AACL-IJCNLP2020", "Official Implementation"]
 categories: ["Natural Language Processing", "Glyph-aware NLP", "NLP for Asian Languages"]
 featured: false
 

--- a/content/publication/daif2020aradic/index.md
+++ b/content/publication/daif2020aradic/index.md
@@ -34,7 +34,7 @@ AraDIC shows performance improvement over classical and deep learning baselines 
 # Summary. An optional shortened abstract.
 summary: "Proc. ACL SRW 2020"
 
-tags: ["International Publication", "Refereed", "Natural Language Processing", "ACL", "ACL2020"]
+tags: ["International Publication", "Refereed", "Natural Language Processing", "ACL", "ACL2020", "Official Implementation"]
 categories: ["Natural Language Processing", "NLP for Arabic", "Image-based Character Embedding"]
 featured: false
 

--- a/content/publication/iwai2024layout/index.md
+++ b/content/publication/iwai2024layout/index.md
@@ -25,7 +25,7 @@ abstract: "Layout generation is a task to synthesize a harmonious layout with el
 # Summary. An optional shortened abstract.
 summary: "Proc. of ECCV2024 (**Acceptance rate = 27.9%**)"
 
-tags: ["International Conference", "Refereed", "Layout Generation", "Discrete Diffusion Model", "LYCorp", "International Publication", "Springer", "ECCV", "ECCV2024"]
+tags: ["International Conference", "Refereed", "Layout Generation", "Discrete Diffusion Model", "LYCorp", "International Publication", "Springer", "ECCV", "ECCV2024", "Official Implementation"]
 categories: ["Layout Generation", "Creative Graphic Design"]
 featured: true
 

--- a/content/publication/kawada2026sciga/index.md
+++ b/content/publication/kawada2026sciga/index.md
@@ -27,7 +27,7 @@ summary: "Findings of CVPR2026 (**Acceptance rate = 36.09%**)"
 aliases:
   - /publication/kawada2025sciga/
 
-tags: ["International Conference", "Refereed", "AI for Science", "Natural Language Processing", "Computer Vision", "Vision & Language", "Dataset", "CVPR", "CVPR2026", "Posters"]
+tags: ["International Conference", "Refereed", "AI for Science", "Natural Language Processing", "Computer Vision", "Vision & Language", "Dataset", "CVPR", "CVPR2026", "Posters", "Official Implementation"]
 categories: ["Natural Language Processing", "Vision & Language", "AI for Science"]
 featured: false
 

--- a/layouts/partials/blocks/portfolio.html
+++ b/layouts/partials/blocks/portfolio.html
@@ -93,10 +93,12 @@
     {{ $query = sort $query $sort_by $sort_order }}
 
     {{ range $index, $item := $query }}
+      {{/* Reuse registered publication bundles without exposing every publication in Projects. */}}
       {{ $tags := $item.Params.tags | default (slice) }}
       {{ $is_project := eq $item.Section "project" }}
       {{ $is_poster := and (eq $item.Section "publication") (in $tags "Posters") }}
-      {{ if or $is_project $is_poster }}
+      {{ $is_official_implementation := and (eq $item.Section "publication") (in $tags "Official Implementation") }}
+      {{ if or $is_project $is_poster $is_official_implementation }}
       {{ $js_tag_classes := delimit (apply (apply (apply $item.Params.tags "replace" "." " " "-") "printf" "js-id-%s" ".") "lower" ".") " " }}
         {{ if in (slice "masonry" 3) $view }}
           <div class="project-card project-item isotope-item {{ $js_tag_classes | safeHTMLAttr }}">

--- a/tests/test_hugo_poster_project_sync.py
+++ b/tests/test_hugo_poster_project_sync.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from ruamel.yaml import YAML
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = (
@@ -17,6 +18,25 @@ SCRIPT_PATH = (
     / "scripts"
     / "create_poster_thumbnail.py"
 )
+OFFICIAL_IMPLEMENTATION_PUBLICATIONS = (
+    "aoki2020text",
+    "daif2020aradic",
+    "iwai2024layout",
+    "kawada2026sciga",
+)
+
+
+def test_public_official_implementations_are_in_projects() -> None:
+    yaml = YAML(typ="safe")
+    for slug in OFFICIAL_IMPLEMENTATION_PUBLICATIONS:
+        index_path = REPO_ROOT / "content" / "publication" / slug / "index.md"
+        frontmatter = yaml.load(index_path.read_text().split("---", 2)[1])
+        assert "Official Implementation" in frontmatter["tags"], slug
+
+    portfolio_template = (
+        REPO_ROOT / "layouts" / "partials" / "blocks" / "portfolio.html"
+    ).read_text()
+    assert "$is_official_implementation" in portfolio_template
 
 
 def load_thumbnail_module():


### PR DESCRIPTION
## Summary

- remove the PyTorch, Chainer, and Tool filters from Projects
- keep Official Implementation and label it as Official Implementation 💻
- add GDCE-SSA, AraDIC, Layout-Corrector, and SciGA to Official Implementation
- include tagged publication pages in the Projects portfolio

## Validation

- `uv run --with pytest --with ruamel.yaml pytest tests/ -q` (39 passed)
- `uv run --with ruamel.yaml python scripts/lint_frontmatter.py`
- `uvx ruff check tests/test_hugo_poster_project_sync.py`
- `uvx ruff format --check tests/test_hugo_poster_project_sync.py`
- `mise exec -- hugo --gc --minify --printUnusedTemplates`
- verified that the generated Official Implementation filter contains 7 cards