### PR TITLE
fix: check IEEE PDF links via document pages

### DIFF
--- a/.lychee/config.toml
+++ b/.lychee/config.toml
@@ -11,3 +11,9 @@ retry_wait_time = 10
 
 # Comma-separated list of accepted status codes for valid links.
 accept = ["100..=103", "200..=299", "302"]
+
+# IEEE Xplore rejects automated requests to PDF endpoints with HTTP 418.
+# Check the corresponding document pages while preserving the PDF links on the site.
+remap = [
+  '^https://ieeexplore\.ieee\.org/stamp/stamp\.jsp\?tp=&arnumber=([0-9]+)$ https://ieeexplore.ieee.org/document/$1',
+]


### PR DESCRIPTION
## Summary

- preserve the IEEE Xplore PDF links shown on the site
- remap IEEE `stamp.jsp` URLs to their corresponding `/document/<arnumber>` pages only during lychee checks
- avoid false failures from IEEE's HTTP 418 bot rejection while still verifying that each paper exists

Fixes the IEEE failures in https://github.com/shunk031/shunk031.github.io/actions/runs/31365093090.

## Verification

- `mise exec -- lychee --config .lychee/config.toml --format detailed --no-progress -` for both affected IEEE URLs: 2 successful, 0 errors
- `mise exec -- hugo --gc --minify --printUnusedTemplates`: passed
- `make check-broken-links`: IEEE errors resolved; the full command currently fails only on an unrelated `ken.ieice.org` URL returning HTTP 403
