### PR TITLE
fix: enable Projects header link

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -52,9 +52,9 @@ main:
     url: "#experience"
     weight: 7
 
-  # - name: 📂 Projects
-  #   url: "#projects"
-  #   weight: 8
+  - name: 📂 Projects
+    url: "#projects"
+    weight: 8
 # Link to a PDF of your resume/CV from the menu.
 # To enable, copy your resume/CV to `static/uploads/resume.pdf` and uncomment the lines below.
 #  - name: CV


### PR DESCRIPTION
## Summary

- enable the Projects item in the header navigation
- link it to the existing `#projects` section

## Validation

- `mise exec -- hugo --gc --minify --printUnusedTemplates`
- confirmed the generated navigation contains `href=/#projects`
- `git diff --check`