### PR TITLE
fix: publish generated presentation news immediately

### DIFF
--- a/.agents/skills/hugo-conference-news-sync/SKILL.md
+++ b/.agents/skills/hugo-conference-news-sync/SKILL.md
@@ -37,7 +37,8 @@ uv run --with ruamel.yaml python scripts/sync_conference_news.py --repo-root <re
 - Initialize each new news file with `make news name="<generated-slug>"` before writing final content.
 - For both presentation-style and acceptance-style conference news, set tags to `["News", "<CONF>", "<CONF><YEAR>"]`.
 - Use `--draft` only when intentionally creating unpublished drafts.
-- Set `date` and `lastmod` to the earliest publication `date` in the conference-year group.
+- For presentation-style news, set `date` and `lastmod` to the generation time so the announcement is published when the news file is created, not on the future conference date.
+- For acceptance-style news, set `date` and `lastmod` to the earliest publication `date` in the conference-year group.
 - Skip groups already referenced by existing news publication links.
 
 4. Validate output.

--- a/content/news/yans-2026-presentations/index.md
+++ b/content/news/yans-2026-presentations/index.md
@@ -7,8 +7,8 @@ summary: ""
 authors: ["Shunsuke Kitada"]
 tags: ["News", "YANS", "YANS2026"]
 categories: ["News"]
-date: 2026-08-17T00:00:00+09:00
-lastmod: 2026-08-17T00:00:00+09:00
+date: 2026-08-16T12:01:13+09:00
+lastmod: 2026-08-16T12:01:13+09:00
 featured: false
 draft: false
 

--- a/scripts/sync_conference_news.py
+++ b/scripts/sync_conference_news.py
@@ -388,7 +388,7 @@ def render_news_markdown(
     publications: list[Publication],
     *,
     author: str,
-    conference_date: str,
+    news_date: str,
     draft: bool,
 ) -> str:
     """Render a complete `content/news/<slug>/index.md` markdown string."""
@@ -416,8 +416,8 @@ def render_news_markdown(
         f'authors: ["{author}"]',
         news_tags,
         'categories: ["News"]',
-        f"date: {conference_date}",
-        f"lastmod: {conference_date}",
+        f"date: {news_date}",
+        f"lastmod: {news_date}",
         "featured: false",
         f"draft: {'true' if draft else 'false'}",
         "",
@@ -472,6 +472,18 @@ def resolve_conference_date(publications: list[Publication], fallback: str) -> s
         return fallback
     parsed.sort(key=lambda x: x[0])
     return parsed[0][1]
+
+
+def resolve_news_date(
+    conf: ConferenceKey,
+    publications: list[Publication],
+    generated_at: str,
+) -> str:
+    """Use creation time for presentation news and publication dates for acceptance news."""
+
+    if conf.news_kind == NEWS_KIND_PRESENTATIONS:
+        return generated_at
+    return resolve_conference_date(publications, generated_at)
 
 
 def initialize_news_file(repo_root: Path, news_dir: Path, out_file: Path, slug: str) -> str:
@@ -635,7 +647,7 @@ def main() -> None:
             conf,
             items,
             author=args.author,
-            conference_date=resolve_conference_date(items, now_iso),
+            news_date=resolve_news_date(conf, items, now_iso),
             draft=draft,
         )
 

--- a/tests/test_sync_conference_news.py
+++ b/tests/test_sync_conference_news.py
@@ -59,13 +59,70 @@ def test_render_news_markdown_keeps_conference_tags_for_acceptance_news() -> Non
         conf,
         publications,
         author="Shunsuke Kitada",
-        conference_date="2026-02-21T00:00:00+00:00",
+        news_date="2026-02-21T00:00:00+00:00",
         draft=False,
     )
 
     assert 'title: "Accepted our paper to Findings of CVPR 2026"' in markdown
     assert 'tags: ["News", "CVPR", "CVPR2026"]' in markdown
     assert "The following paper has been accepted to Findings of CVPR 2026:" in markdown
+
+
+def test_resolve_news_date_uses_generation_time_for_presentations() -> None:
+    module = load_sync_conference_news_module()
+
+    conf = module.ConferenceKey(
+        name="YANS",
+        year="2026",
+        display_label="YANS 2026",
+        news_kind=module.NEWS_KIND_PRESENTATIONS,
+    )
+    publication = module.Publication(
+        path=Path("content/publication/example2026yans/index.md"),
+        slug="example2026yans",
+        title="Example presentation",
+        authors=["Shunsuke Kitada"],
+        date="2026-08-17T00:00:00+09:00",
+        conf=conf,
+    )
+    generated_at = "2026-08-16T12:01:13+09:00"
+
+    assert module.resolve_news_date(conf, [publication], generated_at) == generated_at
+
+
+def test_resolve_news_date_keeps_earliest_publication_date_for_acceptance() -> None:
+    module = load_sync_conference_news_module()
+
+    conf = module.ConferenceKey(
+        name="CVPR",
+        year="2026",
+        display_label="CVPR 2026",
+        news_kind=module.NEWS_KIND_ACCEPTANCE,
+    )
+    publications = [
+        module.Publication(
+            path=Path("content/publication/later2026cvpr/index.md"),
+            slug="later2026cvpr",
+            title="Later paper",
+            authors=["Shunsuke Kitada"],
+            date="2026-02-21T00:00:00+00:00",
+            conf=conf,
+        ),
+        module.Publication(
+            path=Path("content/publication/earlier2026cvpr/index.md"),
+            slug="earlier2026cvpr",
+            title="Earlier paper",
+            authors=["Shunsuke Kitada"],
+            date="2026-02-20T00:00:00+00:00",
+            conf=conf,
+        ),
+    ]
+    generated_at = "2026-03-01T00:00:00+00:00"
+
+    assert (
+        module.resolve_news_date(conf, publications, generated_at)
+        == "2026-02-20T00:00:00+00:00"
+    )
 
 
 def test_render_news_markdown_prioritizes_site_owner_first_author_papers() -> None:
@@ -100,7 +157,7 @@ def test_render_news_markdown_prioritizes_site_owner_first_author_papers() -> No
         conf,
         publications,
         author="Shunsuke Kitada",
-        conference_date="2026-08-03T00:00:00+09:00",
+        news_date="2026-08-03T00:00:00+09:00",
         draft=False,
     )
 


### PR DESCRIPTION
## Why

Conference presentation news was generated with the conference or publication date, so a post for a future conference could remain unpublished until that date. The existing YANS 2026 post also needed its one-off metadata correction. Acceptance-style news should continue to use the earliest publication date.

## What Changed

- Kept the existing YANS 2026 presentation news post and its merge-time `date`/`lastmod` correction.
- Set generated presentation news `date` and `lastmod` to the generation time.
- Kept acceptance-style news `date` and `lastmod` at the earliest publication date.
- Added regression coverage for both date policies and updated the renderer argument name.
- Updated the conference-news sync skill guidance; no duplicate news pages were created.

## Validation

The focused conference-news regression tests passed.

```shell
uv run --with pytest --with ruamel.yaml pytest tests/test_sync_conference_news.py -q
```

The full test suite passed.

```shell
uv run --with pytest --with ruamel.yaml pytest tests/ -q
```

Frontmatter lint passed for all 193 files; only the known pre-existing casing warnings were reported.

```shell
uv run --with ruamel.yaml python scripts/lint_frontmatter.py
```

The YANS 2026 dry-run found the existing linked news and created no duplicate post.

```shell
uv run --with ruamel.yaml python scripts/sync_conference_news.py --target "YANS 2026" --dry-run
```

The Hugo build completed successfully with only the existing HugoBlox unused-template warnings.

```shell
mise exec -- hugo --gc --minify --printUnusedTemplates
```

The committed diff passed the whitespace check.

```shell
git diff --check HEAD^ HEAD
```
