### PR TITLE
ci: auto-merge all Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,10 +22,8 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Enable auto-merge for Dependabot PRs
-        # Auto-merge only non-major Dependabot updates.
-        # Major updates are intentionally left for manual review because they may
-        # introduce breaking changes even when the current checks are green.
-        if: ${{ startsWith(steps.metadata.outputs.update-type, 'version-update:') && steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        # Auto-merge all Dependabot version updates, including semver-major.
+        if: ${{ startsWith(steps.metadata.outputs.update-type, 'version-update:') }}
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR requests approval to auto-merge Dependabot version updates, including semver-major updates. The existing workflow still limits execution to Dependabot PRs, reads Dependabot metadata, and uses GitHub's squash auto-merge path; the only policy change is removing the semver-major manual-review exception. Required checks and branch protection therefore remain the gate before merging.

## Validation

All checks passed:

- `make setup` confirmed that the repository tools are installed.
- YAML parsing confirmed that the workflow remains syntactically valid.
- `git diff --check` confirmed that the patch has no whitespace errors.
- `uv run --with pytest --with ruamel.yaml pytest tests/ -q` completed with 43 passing tests.
