### PR TITLE
feat(news): link K Program project page

### DIFF
--- a/content/news/appointed-uectokyo-kprogram-llm-research/index.md
+++ b/content/news/appointed-uectokyo-kprogram-llm-research/index.md
@@ -8,7 +8,7 @@ authors: ["Shunsuke Kitada"]
 tags: ["News"]
 categories: ["News"]
 date: 2025-05-19T00:00:00+09:00
-lastmod: 2025-05-19T00:00:00+09:00
+lastmod: 2026-08-18T00:00:00+09:00
 featured: false
 draft: false
 
@@ -35,3 +35,5 @@ Looking forward to making an impact in both industry and academia!
 {{< blogcard url="https://www.jst.go.jp/k-program/program/cyber2.html" >}}
 
 {{< blogcard url="https://projectdb.jst.go.jp/grant/JST-PROJECT-24017354/" >}}
+
+{{< blogcard url="https://kpro.mdl.comp.isct.ac.jp/" >}}


### PR DESCRIPTION
## Why

Added the current University of Tokyo K Program project-page link to the research announcement so readers can find the project's latest information from the existing page.

## What Changed

- Added a blogcard for `https://kpro.mdl.comp.isct.ac.jp/`.
- Updated the page's `lastmod` to `2026-08-18T00:00:00+09:00`.

## Validation

The Hugo site builds successfully with the CI-equivalent command.

```shell
mise exec -- hugo --gc --minify --printUnusedTemplates
```

Frontmatter validation passes.

```shell
uv run --with ruamel.yaml python scripts/lint_frontmatter.py
```

The generated page contains the new project URL.

```shell
rg -n 'kpro\.mdl\.comp\.isct\.ac\.jp' public/news/appointed-uectokyo-kprogram-llm-research/index.html
```

The local broken-link check passes.

```shell
make check-broken-links
```

Please verify the destination page and approve this content-only change.
